### PR TITLE
Fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ tune the sanitizer. Details about the Popeye configuration file are below.
 popeye version
 # Popeye a cluster using your current kubeconfig environment.
 popeye
-# Popeye uses a spinach config file of course! aka spinchyaml!
+# Popeye uses a spinach config file of course! aka spinachyaml!
 popeye -f spinach.yml
 # Popeye a cluster using a kubeconfig context.
 popeye --context olive
@@ -121,7 +121,7 @@ popeye help
 
 <img src="assets/a_score.png"/>
 
-## The SpinchYAML Configuration
+## The SpinachYAML Configuration
 
 NOTE: This file will change as Popeye matures!
 

--- a/internal/linter/container.go
+++ b/internal/linter/container.go
@@ -91,7 +91,7 @@ func (c *Container) checkResources(co v1.Container) {
 func (c *Container) checkNamedPorts(co v1.Container) {
 	for _, p := range co.Ports {
 		if len(p.Name) == 0 {
-			c.addIssuef(co.Name, WarnLevel, "Unamed port `%d", p.ContainerPort)
+			c.addIssuef(co.Name, WarnLevel, "Unnamed port `%d", p.ContainerPort)
 		}
 	}
 }


### PR DESCRIPTION
Tiny commit, fixed typos:
spinchyaml -> spinachyaml
unamed -> unnamed