### PR TITLE
ExternalName services do not employ Endpoints objects

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -188,6 +188,16 @@ func (c *Client) GetEndpoints(svcFQN string) (*v1.Endpoints, error) {
 	if ep, ok := eps[svcFQN]; ok {
 		return &ep, nil
 	}
+	svcs, err := c.ListServices()
+	if err != nil {
+		return nil, err
+	}
+	for _, svc := range svcs {
+		// ExternalName does not use Endpoints
+		if svc.Namespace+"/"+svc.Name == svcFQN && svc.Spec.Type == v1.ServiceTypeExternalName {
+			return nil, nil
+		}
+	}
 
 	return nil, fmt.Errorf("Unable to find ep for service %s", svcFQN)
 }


### PR DESCRIPTION
If you read the service specs in Kubernetes website you'll find that ExternalName are merely CNAME-alike types, and as such, don't employ the concept of Endpoints.