### PR TITLE
Corrects ExternalName-typed services reporting missing Endpoints

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -3,8 +3,6 @@ package k8s
 //go:generate popeye gen
 
 import (
-	"fmt"
-
 	"github.com/derailed/popeye/pkg/config"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -156,7 +154,7 @@ func (c *Client) ListCRBs() (map[string]rbacv1.ClusterRoleBinding, error) {
 	return c.allCRBs, nil
 }
 
-// ListEndpoints returns a endpoint by name.
+// ListEndpoints returns a map of Endpoints by name.
 func (c *Client) ListEndpoints() (map[string]v1.Endpoints, error) {
 	if c.eps != nil {
 		return c.eps, nil
@@ -178,7 +176,7 @@ func (c *Client) ListEndpoints() (map[string]v1.Endpoints, error) {
 	return c.eps, nil
 }
 
-// GetEndpoints returns a endpoint by name.
+// GetEndpoints returns an Endpoints reference by name.
 func (c *Client) GetEndpoints(svcFQN string) (*v1.Endpoints, error) {
 	eps, err := c.ListEndpoints()
 	if err != nil {
@@ -188,8 +186,9 @@ func (c *Client) GetEndpoints(svcFQN string) (*v1.Endpoints, error) {
 	if ep, ok := eps[svcFQN]; ok {
 		return &ep, nil
 	}
-
-	return nil, fmt.Errorf("Unable to find ep for service %s", svcFQN)
+	// A service having no endpoints isn't an error in the client, but it *is* something we'll want to determine
+	// in the linter.
+	return nil, nil
 }
 
 // ListServices lists all available services in a given namespace.
@@ -244,8 +243,8 @@ func (c *Client) GetPod(sel map[string]string) (*v1.Pod, error) {
 			return &po, nil
 		}
 	}
-
-	return nil, fmt.Errorf("No pods match service selector")
+	// not getting a pod matching a selector is OK, the linter should determine whether it is an error.
+	return nil, nil
 }
 
 // ListPods list all available pods.

--- a/internal/linter/svc.go
+++ b/internal/linter/svc.go
@@ -2,6 +2,7 @@ package linter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -32,20 +33,19 @@ func (s *Service) Lint(ctx context.Context) error {
 		fqn := svcFQN(svc)
 
 		// Skip internal services...
-		if in(skipServices, svcFQN(svc)) {
+		if in(skipServices, fqn) {
 			continue
 		}
 
 		s.initIssues(fqn)
 		po, err := s.client.GetPod(svc.Spec.Selector)
 		if err != nil {
-			s.addError(svcFQN(svc), err)
+			s.addError(fqn, err)
 		}
 		ep, err := s.client.GetEndpoints(fqn)
 		if err != nil {
 			s.addError(fqn, err)
 		}
-
 		s.lint(svc, po, ep)
 	}
 
@@ -53,22 +53,23 @@ func (s *Service) Lint(ctx context.Context) error {
 }
 
 func (s *Service) lint(svc v1.Service, po *v1.Pod, ep *v1.Endpoints) {
-	if po != nil {
-		s.checkPorts(svc, po)
-	}
-	if ep != nil {
-		s.checkEndpoints(svc, ep)
-	}
+	// if we have a list of selector that didn't return pods, we need to raise this as an error.
+	s.checkPorts(svc, po)
+	s.checkEndpoints(svc, ep)
 	s.checkType(svc)
 }
 
 func (s *Service) checkType(svc v1.Service) {
 	if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
-		s.addIssue(svcFQN(svc), InfoLevel, "Type Loadbalancer detected. Could be expensive!")
+		s.addIssue(svcFQN(svc), InfoLevel, "Type Loadbalancer detected. Could be expensive")
 	}
 }
 
 func (s *Service) checkPorts(svc v1.Service, po *v1.Pod) {
+	if po == nil && len(svc.Spec.Selector) > 0{
+		s.addError(svcFQN(svc), errors.New("No pod found for selector"))
+		return
+	}
 	for _, p := range svc.Spec.Ports {
 		errs := checkServicePort(svc.Name, po, p)
 		if errs != nil {
@@ -80,11 +81,16 @@ func (s *Service) checkPorts(svc v1.Service, po *v1.Pod) {
 
 // CheckEndpoints runs a sanity check on all endpoints in a given namespace.
 func (s *Service) checkEndpoints(svc v1.Service, ep *v1.Endpoints) {
-	if svc.Spec.Type == v1.ClusterIPNone {
+	// skip out on externalName services
+	if svc.Spec.Type == v1.ServiceTypeExternalName {
 		return
 	}
-
-	if len(ep.Subsets) == 0 {
+	// skip out on services that have no clusterIP
+	if svc.Spec.ClusterIP == v1.ClusterIPNone {
+		return
+	}
+	// At this point we have services with ClusterIPs, and therefore should have services with Endpoints.
+	if ep == nil || len(ep.Subsets) == 0 {
 		s.addError(svcFQN(svc), fmt.Errorf("No associated endpoints"))
 	}
 }


### PR DESCRIPTION
This change moves the decision to error on missing endpoints/pods for a
service from k8s/client.go to linter/svc.go. In the cases where the svc
has no ClusterIP (where it is explicitly None, or not allowed such as
in the ExternalName svc type) we'll skip the check for Endpoints.