### PR TITLE
Use ASCII percentage symbol in Jurassic Mode

### DIFF
--- a/internal/report/tally.go
+++ b/internal/report/tally.go
@@ -81,7 +81,11 @@ func (t *Tally) write(w io.Writer, s *Sanitizer) {
 	if score < 80 {
 		color = ColorRed
 	}
-	fmt.Fprintf(w, "%s٪", s.Color(strconv.Itoa(score), color))
+	percentageSign := "٪"
+	if s.jurassicMode {
+		percentageSign = "%%"
+	}
+	fmt.Fprintf(w, "%s%s", s.Color(strconv.Itoa(score), color), percentageSign)
 }
 
 // Dump writes out tally and computes length


### PR DESCRIPTION
Thanks for adding Jurassic Mode in v0.2.0 - it definitely makes the output much more readable on terminals with limited character support.

I noticed however that I was still getting a replacement character box in the header tally where a percentage sign should have been, as seen below. It looks like a ٪ (ARABIC PERCENT SIGN) is used instead of an ASCII percentage, and hence can't be displayed on terminals with limited character support - such as Powershell's default configuration.

![image](https://user-images.githubusercontent.com/6966796/56081571-abffe600-5e06-11e9-9f05-0f4cb2577496.png)

This PR changes the string formatting for the header tally to use an ASCII percentage if Jurassic Mode is enabled. This then displays as expected on my terminal with Jurassic Mode enabled;

![image](https://user-images.githubusercontent.com/6966796/56081600-f2eddb80-5e06-11e9-83a8-22b9aa7bbb76.png)

This is the first time i've written anything in Go so hopefully i've done this correctly - i'm open to feedback if there's a better way of doing this!