### PR TITLE
Use Secret linter for secrets

### DIFF
--- a/pkg/popeye.go
+++ b/pkg/popeye.go
@@ -103,7 +103,7 @@ func linters(l linter.Loader, log *zerolog.Logger) Linters {
 		"svc": linter.NewService(l, log),
 		"sa":  linter.NewSA(l, log),
 		"cm":  linter.NewCM(l, log),
-		"sec": linter.NewService(l, log),
+		"sec": linter.NewSecret(l, log),
 	}
 }
 


### PR DESCRIPTION
This is obvious typo - Service linter was used to lint Secrets.