### PR TITLE
Updating PSP to use policy/v1beta1 instead of extensions/v1beta1

### DIFF
--- a/internal/cache/psp.go
+++ b/internal/cache/psp.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	pv1beta1 "k8s.io/api/extensions/v1beta1"
+	pv1beta1 "k8s.io/api/policy/v1beta1"
 )
 
 // PodSecurityPolicyKey tracks PodSecurityPolicy ressource references

--- a/internal/dag/psp.go
+++ b/internal/dag/psp.go
@@ -4,7 +4,7 @@ import (
 	"github.com/derailed/popeye/internal/k8s"
 	"github.com/derailed/popeye/pkg/config"
 	"github.com/rs/zerolog/log"
-	pv1beta1 "k8s.io/api/extensions/v1beta1"
+	pv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -43,5 +43,5 @@ func listAllPodSecurityPolicys(c *k8s.Client) (map[string]*pv1beta1.PodSecurityP
 
 // FetchPodSecurityPolicys retrieves all PodSecurityPolicys on the cluster.
 func fetchPodSecurityPolicys(c *k8s.Client) (*pv1beta1.PodSecurityPolicyList, error) {
-	return c.DialOrDie().ExtensionsV1beta1().PodSecurityPolicies().List(metav1.ListOptions{})
+	return c.DialOrDie().PolicyV1beta1().PodSecurityPolicies().List(metav1.ListOptions{})
 }

--- a/internal/sanitize/psp.go
+++ b/internal/sanitize/psp.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/derailed/popeye/internal/issues"
-	pv1beta1 "k8s.io/api/extensions/v1beta1"
+	pv1beta1 "k8s.io/api/policy/v1beta1"
 )
 
 type (

--- a/internal/sanitize/psp_test.go
+++ b/internal/sanitize/psp_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/derailed/popeye/internal/cache"
 	"github.com/derailed/popeye/internal/issues"
 	"github.com/stretchr/testify/assert"
-	pv1beta1 "k8s.io/api/extensions/v1beta1"
+	pv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 


### PR DESCRIPTION
PodSecurityPolicy apiVersion extensions/v1beta1 has been removed in k8s
1.16