### PR TITLE
Track Secrets used by Ingresses

### DIFF
--- a/internal/cache/ing.go
+++ b/internal/cache/ing.go
@@ -4,7 +4,7 @@ import (
 	nv1beta1 "k8s.io/api/networking/v1beta1"
 )
 
-// IngressKey tracks Ingress ressource references
+// IngressKey tracks Ingress resource references
 const IngressKey = "ing"
 
 // Ingress represents Ingress cache.
@@ -20,4 +20,21 @@ func NewIngress(ings map[string]*nv1beta1.Ingress) *Ingress {
 // ListIngresses returns all available Ingresss on the cluster.
 func (d *Ingress) ListIngresses() map[string]*nv1beta1.Ingress {
 	return d.ings
+}
+
+// IngressRefs computes all ingress external references.
+func (d *Ingress) IngressRefs(refs ObjReferences) {
+	for _, ing := range d.ings {
+		for _, tls := range ing.Spec.TLS {
+			d.trackReference(refs, ResFqn(SecretKey, FQN(ing.Namespace, tls.SecretName)))
+		}
+	}
+}
+
+func (d *Ingress) trackReference(refs ObjReferences, key string) {
+	if set, ok := refs[key]; ok {
+		set.Add(AllKeys)
+	} else {
+		refs[key] = StringSet{AllKeys: Blank}
+	}
 }

--- a/internal/cache/ing_test.go
+++ b/internal/cache/ing_test.go
@@ -1,0 +1,34 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/magiconair/properties/assert"
+	nv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIngressRefs(t *testing.T) {
+	ing := NewIngress(map[string]*nv1beta1.Ingress{
+		"default/ing1": &nv1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+			},
+			Spec: nv1beta1.IngressSpec{
+				TLS: []nv1beta1.IngressTLS{
+					{
+						SecretName: "foo",
+					},
+				},
+			},
+		},
+	})
+
+	refs := ObjReferences{}
+	ing.IngressRefs(refs)
+
+	_, exists := refs["sec:default/foo"]
+
+	assert.Equal(t, len(refs), 1)
+	assert.Equal(t, exists, true)
+}

--- a/internal/report/human.go
+++ b/internal/report/human.go
@@ -7,6 +7,7 @@ import (
 
 func human() map[string]string {
 	return map[string]string{
+		"ing": "ingress",
 		"po":  "pod",
 		"svc": "service",
 		"no":  "node",

--- a/internal/report/human.go
+++ b/internal/report/human.go
@@ -5,27 +5,27 @@ import (
 	"strings"
 )
 
-func human() map[string]string {
-	return map[string]string{
-		"ing": "ingress",
-		"po":  "pod",
-		"svc": "service",
-		"no":  "node",
-		"ns":  "namespace",
-		"sa":  "serviceaccount",
-		"cm":  "configmap",
-		"sec": "secret",
-		"pv":  "persistentvolume",
-		"pvc": "persistentvolumeclaim",
-		"hpa": "horizontalpodautoscaler",
-		"dp":  "deployment",
-		"ds":  "daemonset",
-		"sts": "statefulset",
-		"pdb": "poddisruptionbudget",
-		"np":  "networkpolicy",
-		"psp": "podsecuritypolicy",
-		"rs":  "replicaset",
-		"cl":  "cluster",
+func human() map[string][]string {
+	return map[string][]string{
+		"cl":  {"cluster"},
+		"cm":  {"configmap"},
+		"dp":  {"deployment"},
+		"ds":  {"daemonset"},
+		"hpa": {"horizontalpodautoscaler"},
+		"ing": {"ingress", "ingresses"},
+		"no":  {"node"},
+		"np":  {"networkpolicy", "networkpolicies"},
+		"ns":  {"namespace"},
+		"pdb": {"poddisruptionbudget"},
+		"po":  {"pod"},
+		"psp": {"podsecuritypolicy", "podsecuritypolicies"},
+		"pv":  {"persistentvolume"},
+		"pvc": {"persistentvolumeclaim"},
+		"rs":  {"replicaset"},
+		"sa":  {"serviceaccount"},
+		"sec": {"secret"},
+		"sts": {"statefulset"},
+		"svc": {"service"},
 	}
 }
 
@@ -33,7 +33,7 @@ func human() map[string]string {
 func ResToTitle(r string) string {
 	title := r
 	if t, ok := human()[r]; ok {
-		title = t
+		title = t[0]
 	}
 
 	return title
@@ -41,13 +41,24 @@ func ResToTitle(r string) string {
 
 // Titleize returns a human readable resource name.
 func Titleize(r string, count int) string {
-	title := r
-	if t, ok := human()[r]; ok {
-		title = t
-	}
+	inflections := inflectResourceWord(r)
 
+	title := inflections[0]
 	if count <= 0 || title == "general" {
 		return strings.ToUpper(fmt.Sprintf("%s", title))
 	}
-	return strings.ToUpper(fmt.Sprintf("%s (%d scanned)", title+"s", count))
+
+	title = inflections[1]
+	return strings.ToUpper(fmt.Sprintf("%s (%d scanned)", title, count))
+}
+
+func inflectResourceWord(r string) []string {
+	inflections := []string{r}
+	if i, ok := human()[r]; ok {
+		inflections = i
+	}
+	if len(inflections) == 1 {
+		inflections = []string{inflections[0], inflections[0] + "s"}
+	}
+	return inflections
 }

--- a/internal/report/human_test.go
+++ b/internal/report/human_test.go
@@ -7,23 +7,33 @@ import (
 )
 
 func TestTitleize(t *testing.T) {
-	uu := map[string]string{
-		"po":   "PODS (1 SCANNED)",
-		"no":   "NODES (1 SCANNED)",
-		"svc":  "SERVICES (1 SCANNED)",
-		"blee": "BLEES (1 SCANNED)",
-		"sa":   "SERVICEACCOUNTS (1 SCANNED)",
-		"ns":   "NAMESPACES (1 SCANNED)",
-		"cm":   "CONFIGMAPS (1 SCANNED)",
-		"sec":  "SECRETS (1 SCANNED)",
-		"pv":   "PERSISTENTVOLUMES (1 SCANNED)",
-		"pvc":  "PERSISTENTVOLUMECLAIMS (1 SCANNED)",
-		"hpa":  "HORIZONTALPODAUTOSCALERS (1 SCANNED)",
-		"dp":   "DEPLOYMENTS (1 SCANNED)",
-		"sts":  "STATEFULSETS (1 SCANNED)",
+	uu := map[string][]string{
+		"cl":  {"CLUSTER", "CLUSTERS (1 SCANNED)"},
+		"cm":  {"CONFIGMAP", "CONFIGMAPS (1 SCANNED)"},
+		"dp":  {"DEPLOYMENT", "DEPLOYMENTS (1 SCANNED)"},
+		"ds":  {"DAEMONSET", "DAEMONSETS (1 SCANNED)"},
+		"hpa": {"HORIZONTALPODAUTOSCALER", "HORIZONTALPODAUTOSCALERS (1 SCANNED)"},
+		"ing": {"INGRESS", "INGRESSES (1 SCANNED)"},
+		"no":  {"NODE", "NODES (1 SCANNED)"},
+		"np":  {"NETWORKPOLICY", "NETWORKPOLICIES (1 SCANNED)"},
+		"ns":  {"NAMESPACE", "NAMESPACES (1 SCANNED)"},
+		"pdb": {"PODDISRUPTIONBUDGET", "PODDISRUPTIONBUDGETS (1 SCANNED)"},
+		"po":  {"POD", "PODS (1 SCANNED)"},
+		"psp": {"PODSECURITYPOLICY", "PODSECURITYPOLICIES (1 SCANNED)"},
+		"pv":  {"PERSISTENTVOLUME", "PERSISTENTVOLUMES (1 SCANNED)"},
+		"pvc": {"PERSISTENTVOLUMECLAIM", "PERSISTENTVOLUMECLAIMS (1 SCANNED)"},
+		"rs":  {"REPLICASET", "REPLICASETS (1 SCANNED)"},
+		"sa":  {"SERVICEACCOUNT", "SERVICEACCOUNTS (1 SCANNED)"},
+		"sec": {"SECRET", "SECRETS (1 SCANNED)"},
+		"sts": {"STATEFULSET", "STATEFULSETS (1 SCANNED)"},
+		"svc": {"SERVICE", "SERVICES (1 SCANNED)"},
+
+		// Fallback
+		"blee": {"BLEE", "BLEES (1 SCANNED)"},
 	}
 
 	for k, e := range uu {
-		assert.Equal(t, e, Titleize(k, 1))
+		assert.Equal(t, e[0], Titleize(k, 0))
+		assert.Equal(t, e[1], Titleize(k, 1))
 	}
 }

--- a/internal/sanitize/sa_test.go
+++ b/internal/sanitize/sa_test.go
@@ -92,6 +92,8 @@ func (s sa) ListPods() map[string]*v1.Pod {
 	}
 }
 
+func (s sa) IngressRefs(cache.ObjReferences) {}
+
 func (s sa) ServiceAccountRefs(cache.ObjReferences) {}
 
 func (s sa) PodRefs(cache.ObjReferences) {}

--- a/internal/sanitize/secret.go
+++ b/internal/sanitize/secret.go
@@ -20,10 +20,16 @@ type (
 		ServiceAccountRefs(cache.ObjReferences)
 	}
 
+	// IngressRefs tracks Ingress object references.
+	IngressRefs interface {
+		IngressRefs(cache.ObjReferences)
+	}
+
 	// SecretLister list available Secrets on a cluster.
 	SecretLister interface {
 		PodRefs
 		SARefs
+		IngressRefs
 		ListSecrets() map[string]*v1.Secret
 	}
 )
@@ -42,6 +48,7 @@ func (s *Secret) Sanitize(context.Context) error {
 
 	s.PodRefs(refs)
 	s.ServiceAccountRefs(refs)
+	s.IngressRefs(refs)
 	s.checkInUse(refs)
 
 	return nil

--- a/internal/sanitize/secret_test.go
+++ b/internal/sanitize/secret_test.go
@@ -49,6 +49,8 @@ func (m secretMock) PodRefs(refs cache.ObjReferences) {
 	}
 }
 
+func (m secretMock) IngressRefs(cache.ObjReferences) {}
+
 func (m secretMock) ServiceAccountRefs(refs cache.ObjReferences) {
 	refs["sec:default/sec5"] = cache.StringSet{
 		"all": cache.Blank,

--- a/internal/scrub/sa.go
+++ b/internal/scrub/sa.go
@@ -17,6 +17,7 @@ type ServiceAccount struct {
 	*cache.ClusterRoleBinding
 	*cache.RoleBinding
 	*cache.Secret
+	*cache.Ingress
 }
 
 // NewServiceAccount return a new ServiceAccount sanitizer.
@@ -52,6 +53,12 @@ func NewServiceAccount(c *Cache, codes *issues.Codes) Sanitizer {
 		s.AddErr("secrets", err)
 	}
 	s.Secret = cache.NewSecret(secrets)
+
+	ing, err := c.ingresses()
+	if err != nil {
+		s.AddErr("ingresses", err)
+	}
+	s.Ingress = ing
 
 	return &s
 }

--- a/internal/scrub/sec.go
+++ b/internal/scrub/sec.go
@@ -15,6 +15,7 @@ type Secret struct {
 	*cache.Secret
 	*cache.Pod
 	*cache.ServiceAccount
+	*cache.Ingress
 }
 
 // NewSecret return a new Secret sanitizer.
@@ -38,6 +39,12 @@ func NewSecret(c *Cache, codes *issues.Codes) Sanitizer {
 		s.AddErr("serviceaccounts", err)
 	}
 	s.ServiceAccount = sas
+
+	ing, err := c.ingresses()
+	if err != nil {
+		s.AddErr("ingresses", err)
+	}
+	s.Ingress = ing
 
 	return &s
 }


### PR DESCRIPTION
Currently, when running Popeye, I get the issue that certain Secrets are not referenced by other resources but in reality, they are being used by Ingresses.
This Pull Request tracks Secrets used by Ingress and improves the inflection for pluralized words in the report for humans.