### PR TITLE
ADD Support to return Score as Exit code

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,10 @@ func doIt(cmd *cobra.Command, args []string) {
 	if err := popeye.Sanitize(); err != nil {
 		bomb(err.Error())
 	}
+
+	if *flags.ScoreExitCode == true {
+		os.Exit(popeye.GetScore())
+	}
 }
 
 func bomb(msg string) {
@@ -243,6 +247,13 @@ func initFlags() {
 		"pushgateway-address",
 		"",
 		"Address of pushgateway e.g. http://localhost:9091",
+	)
+	rootCmd.Flags().BoolVarP(
+		flags.ScoreExitCode,
+		"score-exit-code",
+		"x",
+		false,
+		"Use Score as Exit Code",
 	)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,7 +70,7 @@ func doIt(cmd *cobra.Command, args []string) {
 		bomb(err.Error())
 	}
 
-	if *flags.ScoreExitCode == true {
+	if *flags.ScoreExitCode {
 		os.Exit(popeye.GetScore())
 	}
 }

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -17,6 +17,7 @@ type Flags struct {
 	Spinach            *string
 	Sections           *[]string
 	PushGatewayAddress *string
+	ScoreExitCode      *bool
 }
 
 // NewFlags returns new configuration flags.
@@ -31,7 +32,8 @@ func NewFlags() *Flags {
 		Spinach:            strPtr(""),
 		Sections:           &[]string{},
 		ConfigFlags:        genericclioptions.NewConfigFlags(false),
-		PushGatewayAddress: strPtr("")}
+		PushGatewayAddress: strPtr(""),
+		ScoreExitCode:      boolPtr(false)}
 }
 
 // OutputFormat returns the report output format.

--- a/pkg/popeye.go
+++ b/pkg/popeye.go
@@ -89,6 +89,12 @@ func (p *Popeye) Sanitize() error {
 	return p.dump(true)
 }
 
+
+// GetScore returns cluster total score
+func (p *Popeye) GetScore() int {
+	return p.builder.Report.Score
+}
+
 func (p *Popeye) dumpJunit() error {
 	res, err := p.builder.ToJunit()
 	if err != nil {


### PR DESCRIPTION
## Change Description
This change is introduced to give Popeye the ability to return the Score as Exit code, this is useful so Popeye can be used for instrumentation (e.g. metrics or automated testing).

## Usage
Popeye will continue to return same Exit codes by default (0 if no error) but with the -x (or --score-exit-code ) will replace the exit code by the value of Score.

## Testing
_make test_ successfully ran
