### PR TITLE
Cannot find a valid Role name referenced by a RoleBinding

### DIFF
--- a/internal/sanitize/crb.go
+++ b/internal/sanitize/crb.go
@@ -59,8 +59,9 @@ func (c *ClusterRoleBinding) checkInUse(ctx context.Context) {
 				c.AddCode(ctx, 1300, crb.RoleRef.Kind, crb.RoleRef.Name)
 			}
 		case "Role":
-			if _, ok := c.ListRoles()[crb.RoleRef.Name]; !ok {
-				c.AddCode(ctx, 1300, crb.RoleRef.Kind, crb.RoleRef.Name)
+			roleFullName := crb.ObjectMeta.Namespace + "/" + crb.RoleRef.Name
+			if _, ok := c.ListRoles()[roleFullName]; !ok {
+				c.AddCode(ctx, 1300, crb.RoleRef.Kind, roleFullName)
 			}
 		}
 

--- a/internal/sanitize/crb.go
+++ b/internal/sanitize/crb.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/derailed/popeye/internal"
+	"github.com/derailed/popeye/internal/cache"
 	"github.com/derailed/popeye/internal/issues"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -59,9 +60,9 @@ func (c *ClusterRoleBinding) checkInUse(ctx context.Context) {
 				c.AddCode(ctx, 1300, crb.RoleRef.Kind, crb.RoleRef.Name)
 			}
 		case "Role":
-			roleFullName := crb.ObjectMeta.Namespace + "/" + crb.RoleRef.Name
-			if _, ok := c.ListRoles()[roleFullName]; !ok {
-				c.AddCode(ctx, 1300, crb.RoleRef.Kind, roleFullName)
+			rFQN := cache.FQN(crb.Namespace, crb.RoleRef.Name)
+			if _, ok := c.ListRoles()[rFQN]; !ok {
+				c.AddCode(ctx, 1300, crb.RoleRef.Kind, rFQN)
 			}
 		}
 

--- a/internal/sanitize/crb_test.go
+++ b/internal/sanitize/crb_test.go
@@ -18,11 +18,11 @@ func TestCRBSanitize(t *testing.T) {
 		issues []config.ID
 	}{
 		"exists": {
-			key:    "default/crb1",
+			key:    "crb1",
 			lister: makeCRBLister(crbOpts{name: "crb1", refKind: "ClusterRole", refName: "cr1"}),
 		},
 		"not_exists": {
-			key:    "default/crb1",
+			key:    "crb1",
 			lister: makeCRBLister(crbOpts{name: "crb1", refKind: "ClusterRole", refName: "blah"}),
 			issues: []config.ID{1300},
 		},
@@ -60,7 +60,7 @@ func makeCRBLister(opts crbOpts) *crb {
 
 func (c *crb) ListClusterRoleBindings() map[string]*rbacv1.ClusterRoleBinding {
 	return map[string]*rbacv1.ClusterRoleBinding{
-		"default/crb1": makeCRB(c.opts.name, c.opts.refKind, c.opts.refName),
+		c.opts.name: makeCRB(c.opts.name, c.opts.refKind, c.opts.refName),
 	}
 }
 

--- a/internal/sanitize/rb.go
+++ b/internal/sanitize/rb.go
@@ -42,8 +42,9 @@ func (r *RoleBinding) Sanitize(ctx context.Context) error {
 				r.AddCode(ctx, 1300, rb.RoleRef.Kind, rb.RoleRef.Name)
 			}
 		case "Role":
-			if _, ok := r.ListRoles()[rb.RoleRef.Name]; !ok {
-				r.AddCode(ctx, 1300, rb.RoleRef.Kind, rb.RoleRef.Name)
+			roleFullName := rb.ObjectMeta.Namespace + "/" + rb.RoleRef.Name
+			if _, ok := r.ListRoles()[roleFullName]; !ok {
+				r.AddCode(ctx, 1300, rb.RoleRef.Kind, roleFullName)
 			}
 		}
 

--- a/internal/sanitize/rb.go
+++ b/internal/sanitize/rb.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/derailed/popeye/internal"
+	"github.com/derailed/popeye/internal/cache"
 	"github.com/derailed/popeye/internal/issues"
 )
 
@@ -42,9 +43,9 @@ func (r *RoleBinding) Sanitize(ctx context.Context) error {
 				r.AddCode(ctx, 1300, rb.RoleRef.Kind, rb.RoleRef.Name)
 			}
 		case "Role":
-			roleFullName := rb.ObjectMeta.Namespace + "/" + rb.RoleRef.Name
-			if _, ok := r.ListRoles()[roleFullName]; !ok {
-				r.AddCode(ctx, 1300, rb.RoleRef.Kind, roleFullName)
+			rFQN := cache.FQN(rb.Namespace, rb.RoleRef.Name)
+			if _, ok := r.ListRoles()[rFQN]; !ok {
+				r.AddCode(ctx, 1300, rb.RoleRef.Kind, rFQN)
 			}
 		}
 

--- a/internal/sanitize/rb_test.go
+++ b/internal/sanitize/rb_test.go
@@ -19,11 +19,11 @@ func TestRBSanitize(t *testing.T) {
 	}{
 		"used": {
 			key:    "default/rb1",
-			lister: makeRBLister(rbOpts{name: "rb1", refKind: "ClusterRole", refName: "cr1"}),
+			lister: makeRBLister(rbOpts{name: "rb1", refKind: "Role", refName: "r1"}),
 		},
 		"unused": {
 			key:    "default/rb1",
-			lister: makeRBLister(rbOpts{name: "rb1", refKind: "ClusterRole", refName: "blah"}),
+			lister: makeRBLister(rbOpts{name: "rb1", refKind: "Role", refName: "blah"}),
 			issues: []config.ID{1300},
 		},
 	}


### PR DESCRIPTION
Hi, checking my cluster I see the following behaviour:

```
ROLES (2 SCANNED)                                                            💥 0 😱 0 🔊 0 ✅ 2 100٪
┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅
  · logging/elasticsearch-master...................................................................✅
  · logging/logstash-logstash......................................................................✅


ROLEBINDINGS (2 SCANNED)                                                       💥 0 😱 2 🔊 0 ✅ 0 0٪
┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅
  · logging/elasticsearch-master...................................................................😱
    😱 [POP-1300] References a Role (elasticsearch-master) which does not exist.
  · logging/logstash-logstash......................................................................😱
    😱 [POP-1300] References a Role (logstash-logstash) which does not exist.
```

The Roles referenced in the RoleBindings are present.

It seems the `r.ros` map returned by the `ListRoles` method is indexed with a string containing `namespace/rolename`, while `rb.RoleRef.Name` contains the role name only.

I fixed the RoleBinding sanitizer by checking against the full role name, in case of objects of type Role.

The related tests have been updated too.

After the fix:

```
ROLES (2 SCANNED)                                                            💥 0 😱 0 🔊 0 ✅ 2 100٪
┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅
  · logging/elasticsearch-master...................................................................✅
  · logging/logstash-logstash......................................................................✅


ROLEBINDINGS (2 SCANNED)                                                     💥 0 😱 0 🔊 0 ✅ 2 100٪
┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅
  · logging/elasticsearch-master...................................................................✅
  · logging/logstash-logstash......................................................................✅
```