### PR TITLE
Add even less fanciness for jurassic output

### DIFF
--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -60,7 +60,11 @@ func (s *Sanitizer) Open(msg string, t *Tally) {
 		fmt.Fprintf(s, "%s", strings.Repeat(" ", indent))
 		fmt.Fprintf(s, "%s", out)
 	}
-	fmt.Fprintf(s, "\n%s", s.Color(strings.Repeat("┅", Width), ColorLighSlate))
+	titleSeparator := "┅"
+	if s.jurassicMode {
+		titleSeparator = "="
+	}
+	fmt.Fprintf(s, "\n%s", s.Color(strings.Repeat(titleSeparator, Width), ColorLighSlate))
 	fmt.Fprintln(s)
 }
 


### PR DESCRIPTION
This will help with #73.
Even though tests currently do not break we should make sure it stays like this.
There are hard coded title separator in builder_test.go and writer_test.go.