### PR TITLE
Updates for html output

### DIFF
--- a/internal/report/assets/template.html
+++ b/internal/report/assets/template.html
@@ -1,0 +1,52 @@
+<html>
+  <head>
+    <title>Popeye Scan Results</title>
+  </head>
+  <style>
+    .popeye-img {
+      max-width: 175px;
+    }
+    .upper {
+      text-transform: uppercase;
+    }
+    .upper:after {
+      content: 'S';
+    }
+    .msg {
+      margin-left: 25px;
+      display: block;
+    }
+    .issue {
+      display: block;
+    }
+    .summary {
+      display: inline-block;
+    }
+    h2 {
+      color: blue;
+    }
+    h3 {
+      border-bottom: 1px solid black;
+      width: 50%;
+    }
+  </style>
+  <body>
+
+
+    <a href="https://github.com/derailed/popeye"><img class="popeye-img" src="https://github.com/derailed/popeye/raw/master/assets/popeye.png"></a>
+    <span class="summary"><h2>Popeye Summary</h2><span>Your cluster score: <span id="score">{{ .Report.Score }}</span> -- <span id="grade">{{ .Report.Grade }}</span></span></span>
+
+    {{range $val := .Report.Sections }}
+        <h3 id="title"><span class="upper">{{ $val.Title }}</span> (<span id="length">{{ len $val.Outcome }}</span>)
+        <span id="Error">{{ $val.Tally.MarshalYAML.Error }} </span><g-emoji class="g-emoji" alias="boom" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f4a5.png">💥</g-emoji>
+        <span id="Warn">{{ $val.Tally.MarshalYAML.Warn }} </span><g-emoji class="g-emoji" alias="scream" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f631.png">😱</g-emoji>
+        <span id="Info">{{ $val.Tally.MarshalYAML.Info }} </span><g-emoji class="g-emoji" alias="loud_sound" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f50a.png">🔊</g-emoji>
+        <span id="OK">{{ $val.Tally.MarshalYAML.OK }} </span><g-emoji class="g-emoji" alias="white_check_mark" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2705.png">✅</g-emoji>
+        <span id="score">{{ $val.Tally.Score }}</span></h3>
+
+        {{ range $key, $value := $val.Outcome }}<span class="issue">{{ $key }}</span>{{ $length := len $value }}
+        {{ if ne $length 0 }} {{ $temp :=  index $value 0 }}<span class="msg"> {{(index $value 0).Message}}</span>{{ end }}{{ end }}
+    {{end}}
+
+  </body>
+</html>

--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"text/template"
+	"os"
 
 	"github.com/derailed/popeye/internal"
 	"github.com/derailed/popeye/internal/issues"
@@ -25,6 +27,9 @@ const (
 
 	// JSONFormat dumps sanitizer as JSON.
 	JSONFormat = "json"
+
+	// HTMLFormat dumps sanitizer as HTML
+	HTMLFormat = "html"
 
 	// JunitFormat dumps sanitizer as JUnit report.
 	JunitFormat = "junit"
@@ -131,6 +136,17 @@ func (b *Builder) ToJSON() (string, error) {
 	}
 
 	return string(raw), nil
+}
+
+// ToHTML dumps sanitizer to HTML.
+func (b *Builder) ToHTML() (string, error) {
+	b.augment()
+	tmpl, err := template.ParseFiles("./internal/report/assets/template.html")
+	if err != nil { panic(err) }
+	err = tmpl.Execute(os.Stdout, b)
+	if err != nil { panic(err) }
+ 
+	return "", nil
 }
 
 // ToPrometheus returns prometheus pusher.

--- a/pkg/popeye.go
+++ b/pkg/popeye.go
@@ -133,6 +133,16 @@ func (p *Popeye) dumpJSON() error {
 	return nil
 }
 
+func (p *Popeye) dumpHTML() error {
+	res, err := p.builder.ToHTML()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(p.outputTarget, "%v\n", res)
+
+	return nil
+}
+
 func (p *Popeye) dumpScore() error {
 	res, err := p.builder.ToScore()
 	if err != nil {
@@ -186,6 +196,8 @@ func (p *Popeye) dump(printHeader bool) error {
 		err = p.dumpYAML()
 	case report.JSONFormat:
 		err = p.dumpJSON()
+	case report.HTMLFormat:
+		err = p.dumpHTML()
 	case report.PrometheusFormat:
 		err = p.dumpPrometheus()
 	case report.ScoreFormat:
@@ -243,6 +255,8 @@ func (p *Popeye) ensureOutput() error {
 		ext = "xml"
 	case "yaml":
 		ext = "yml"
+	case "html":
+		ext = "html"
 	}
 
 	const outFmt = "sanitizer_%s_%d.%s"


### PR DESCRIPTION
Starter code for HTML output. Closes #73 

Run using: `go run main.go -o html` 

Output in browser: 
![popeye-html-2020-02-10](https://user-images.githubusercontent.com/34528865/74206176-380db480-4c48-11ea-88b2-54bc4b951599.png)
