### PR TITLE
Added option to provide filename

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,6 +101,14 @@ func initPopeyeFlags() {
 	)
 
 	rootCmd.Flags().StringVarP(
+		flags.FileName,
+		"filename",
+		"",
+		"",
+		"Specify the filename for the saved report",
+	)
+
+	rootCmd.Flags().StringVarP(
 		flags.LintLevel,
 		"lint",
 		"l",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,8 +101,8 @@ func initPopeyeFlags() {
 	)
 
 	rootCmd.Flags().StringVarP(
-		flags.FileName,
-		"filename",
+		flags.K8sPopeyeClusterName,
+		"k8s-popeye-cluster-name",
 		"",
 		"",
 		"Specify the filename for the saved report",

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -94,7 +94,7 @@ func (c *Client) ActiveCluster() string {
 	}
 
 	if isSet(c.flags.K8sPopeyeClusterName) {
-		return *c.flags.ClusterName
+		return *c.flags.K8sPopeyeClusterName
 	}
 
 	cfg, err := c.RawConfig()

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -93,6 +93,10 @@ func (c *Client) ActiveCluster() string {
 		return *c.flags.ClusterName
 	}
 
+	if isSet(c.flags.K8sPopeyeClusterName) {
+		return *c.flags.ClusterName
+	}
+
 	cfg, err := c.RawConfig()
 	if err != nil {
 		return "n/a"

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -19,6 +19,7 @@ type Flags struct {
 	Spinach            *string
 	Sections           *[]string
 	PushGatewayAddress *string
+	FileName           *string
 }
 
 // NewFlags returns new configuration flags.
@@ -30,6 +31,7 @@ func NewFlags() *Flags {
 		Save:               boolPtr(false),
 		SaveToS3:           boolPtr(false),
 		S3Bucket:           strPtr(""),
+		FileName:           strPtr(""),
 		ClearScreen:        boolPtr(false),
 		CheckOverAllocs:    boolPtr(false),
 		Spinach:            strPtr(""),

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -8,36 +8,36 @@ import (
 type Flags struct {
 	*genericclioptions.ConfigFlags
 
-	LintLevel          *string
-	Output             *string
-	ClearScreen        *bool
-	Save               *bool
-	SaveToS3           *bool
-	S3Bucket           *string
-	CheckOverAllocs    *bool
-	AllNamespaces      *bool
-	Spinach            *string
-	Sections           *[]string
-	PushGatewayAddress *string
-	FileName           *string
+	LintLevel            *string
+	Output               *string
+	ClearScreen          *bool
+	Save                 *bool
+	SaveToS3             *bool
+	S3Bucket             *string
+	CheckOverAllocs      *bool
+	AllNamespaces        *bool
+	Spinach              *string
+	Sections             *[]string
+	PushGatewayAddress   *string
+	K8sPopeyeClusterName *string
 }
 
 // NewFlags returns new configuration flags.
 func NewFlags() *Flags {
 	return &Flags{
-		LintLevel:          strPtr(defaultLintLevel),
-		Output:             strPtr("standard"),
-		AllNamespaces:      boolPtr(false),
-		Save:               boolPtr(false),
-		SaveToS3:           boolPtr(false),
-		S3Bucket:           strPtr(""),
-		FileName:           strPtr(""),
-		ClearScreen:        boolPtr(false),
-		CheckOverAllocs:    boolPtr(false),
-		Spinach:            strPtr(""),
-		Sections:           &[]string{},
-		ConfigFlags:        genericclioptions.NewConfigFlags(false),
-		PushGatewayAddress: strPtr("")}
+		LintLevel:            strPtr(defaultLintLevel),
+		Output:               strPtr("standard"),
+		AllNamespaces:        boolPtr(false),
+		Save:                 boolPtr(false),
+		SaveToS3:             boolPtr(false),
+		S3Bucket:             strPtr(""),
+		K8sPopeyeClusterName: strPtr(""),
+		ClearScreen:          boolPtr(false),
+		CheckOverAllocs:      boolPtr(false),
+		Spinach:              strPtr(""),
+		Sections:             &[]string{},
+		ConfigFlags:          genericclioptions.NewConfigFlags(false),
+		PushGatewayAddress:   strPtr("")}
 }
 
 // OutputFormat returns the report output format.

--- a/pkg/popeye.go
+++ b/pkg/popeye.go
@@ -37,6 +37,9 @@ var (
 const outFmt = "sanitizer_%s_%d.%s"
 
 func (p *Popeye) fileName() string {
+	if isSetStr(p.flags.FileName) {
+		return fmt.Sprintf(outFmt, *p.flags.FileName, time.Now().UnixNano(), p.fileExt())
+	}
 	return fmt.Sprintf(outFmt, p.client.ActiveCluster(), time.Now().UnixNano(), p.fileExt())
 }
 
@@ -117,7 +120,8 @@ func (p *Popeye) Sanitize() error {
 			}
 		case isSetStr(p.flags.S3Bucket):
 			// Create a single AWS session (we can re use this if we're uploading many files)
-			s, err := session.NewSession(&aws.Config{})
+			s, err := session.NewSession(&aws.Config{
+				LogLevel: aws.LogLevel(aws.LogDebugWithRequestErrors)})
 			if err != nil {
 				log.Fatal().Err(err).Msg("Create S3 Session")
 			}

--- a/pkg/popeye.go
+++ b/pkg/popeye.go
@@ -37,8 +37,8 @@ var (
 const outFmt = "sanitizer_%s_%d.%s"
 
 func (p *Popeye) fileName() string {
-	if isSetStr(p.flags.FileName) {
-		return fmt.Sprintf(outFmt, *p.flags.FileName, time.Now().UnixNano(), p.fileExt())
+	if isSetStr(p.flags.K8sPopeyeClusterName) {
+		return fmt.Sprintf(outFmt, *p.flags.K8sPopeyeClusterName, time.Now().UnixNano(), p.fileExt())
 	}
 	return fmt.Sprintf(outFmt, p.client.ActiveCluster(), time.Now().UnixNano(), p.fileExt())
 }


### PR DESCRIPTION
### Why we need this PR
- Currently, running popeye as a CronJob on K8s saves the filename as `sanitizer_n/a_<timestamp>.txt`
This is due to an [issue](https://github.com/kubernetes/kubernetes/issues/44954) in Kubernetes where API Server does not return the cluster name. 

### What does this PR do
This PR adds an option to provide the filename like shown below:
```
go run main.go --k8s-popeye-cluster-name abcd
Sanitizer saved to: sanitizer_abcd_1581462176820331000.txt
```

- Also added log message to AWS config in case of failure, as it currently does not show any reason.
```
go run main.go --s3-bucket xxxx --k8s-popeye-cluster-name abcd
Sanitizer saved to: sanitizer_abcd_1581462408819395000.txt
2020/02/11 15:06:51 DEBUG: Validate Request s3/PutObject failed, not retrying, error MissingRegion: could not find region configuration
2020/02/11 15:06:51 DEBUG: Build Request s3/PutObject failed, not retrying, error MissingRegion: could not find region configuration
2020/02/11 15:06:51 DEBUG: Sign Request s3/PutObject failed, not retrying, error MissingRegion: could not find region configuration
exit status 1
```

### Further Considerations
I am also considering making the same change [here](https://github.com/derailed/popeye/blob/master/internal/k8s/client.go#L110) as it currently displays the first line of report as `GENERAL [N/A]`. Please let me know what you think 

Signed-off-by: Karan Magdani <karan.magdani@gmail.com>