### PR TITLE
add an output-file flag to specify output file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,20 @@ By default it will create a temp directory and will store the report there,
 the path of the temp directory will be printed out on STDOUT.
 If you have the need to specify the output directory for the report,
 you can use the environment variable `POPEYE_REPORT_DIR`.
+By default, the name of the output file follow the following format : `sanitizer_<cluster-name>_<time-UnixNano>.<output-extension>` (e.g. : "sanitizer-mycluster-1594019782530851873.html").
+If you have the need to specify the output file name for the report,
+you can pass the `--output-file` flag with the filename you want as parameter.
 
 Example to save report in working directory:
 
 ```shell
   $ POPEYE_REPORT_DIR=$(pwd) popeye --save
+```
+
+Example to save report in working directory in HTML format under the name "report.html" :
+
+```shell
+  $ POPEYE_REPORT_DIR=$(pwd) popeye --save --out html --output-file report.html
 ```
 
 ### Save the report to S3

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,6 +96,11 @@ func initPopeyeFlags() {
 		"Specify if you want Popeye to persist the output to a file",
 	)
 
+	rootCmd.Flags().StringVarP(flags.OutputFile, "output-file", "",
+		"",
+		"Specify the name of the saved output file",
+	)
+
 	rootCmd.Flags().StringVarP(flags.S3Bucket, "s3-bucket", "",
 		"",
 		"Specify to which S3 bucket you want to save the output file",
@@ -246,6 +251,9 @@ func initFlags() {
 func checkFlags() error {
 	if flags.OutputFormat() == report.PrometheusFormat && *flags.PushGatewayAddress == "" {
 		return errors.New("Please set pushgateway-address.")
+	}
+	if !*flags.Save && *flags.OutputFile != "" {
+		return errors.New("Please set '--save' flag to use 'output-file'.")
 	}
 	return nil
 }

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -12,6 +12,7 @@ type Flags struct {
 	Output             *string
 	ClearScreen        *bool
 	Save               *bool
+	OutputFile         *string
 	S3Bucket           *string
 	CheckOverAllocs    *bool
 	AllNamespaces      *bool
@@ -30,6 +31,7 @@ func NewFlags() *Flags {
 		Output:             strPtr("standard"),
 		AllNamespaces:      boolPtr(false),
 		Save:               boolPtr(false),
+		OutputFile:         strPtr(""),
 		S3Bucket:           strPtr(""),
 		InClusterName:      strPtr(""),
 		ClearScreen:        boolPtr(false),

--- a/pkg/popeye.go
+++ b/pkg/popeye.go
@@ -434,7 +434,13 @@ func (p *Popeye) ensureOutput() error {
 }
 
 func (p *Popeye) fileName() string {
-	return fmt.Sprintf(outFmt, p.factory.Client().ActiveCluster(), time.Now().UnixNano(), p.fileExt())
+	var fileName string
+	if *p.flags.OutputFile == "" {
+		fileName = fmt.Sprintf(outFmt, p.factory.Client().ActiveCluster(), time.Now().UnixNano(), p.fileExt())
+	} else {
+		fileName = fmt.Sprintf(*p.flags.OutputFile)
+	}
+	return fileName
 }
 
 func (p *Popeye) fileExt() string {

--- a/pkg/popeye.go
+++ b/pkg/popeye.go
@@ -434,13 +434,10 @@ func (p *Popeye) ensureOutput() error {
 }
 
 func (p *Popeye) fileName() string {
-	var fileName string
 	if *p.flags.OutputFile == "" {
-		fileName = fmt.Sprintf(outFmt, p.factory.Client().ActiveCluster(), time.Now().UnixNano(), p.fileExt())
-	} else {
-		fileName = fmt.Sprintf(*p.flags.OutputFile)
-	}
-	return fileName
+		return fmt.Sprintf(outFmt, p.factory.Client().ActiveCluster(), time.Now().UnixNano(), p.fileExt())
+	  }
+	return fmt.Sprintf(*p.flags.OutputFile)
 }
 
 func (p *Popeye) fileExt() string {


### PR DESCRIPTION
Hi !

First, thanks for the great project :)

In my case, I wanted to generate Popeye HTML report file regularly (in a K8S deployment with 2 containers : a first launched from popeye image generates the report in a shared volume and the second one is a nginx container that will server the report as a static page). To achieve this easily, I found it would be convenient to specify the name of the report file because it would allow to set it to "index.html" for example, in order to immediately have the report ready in nginx server default page.

But I guess this PR can also be useful for other needs ;)

PS : It is my first golang contribution so do not hesitate to propose improvements !