### PR TITLE
Add minio scheme for S3-style storage if you're not using Amazon S3

### DIFF
--- a/pkg/popeye.go
+++ b/pkg/popeye.go
@@ -208,14 +208,15 @@ func (p *Popeye) Sanitize() error {
 			var s client2.ConfigProvider
 			// Create a single AWS session (we can re use this if we're uploading many files)
 			if len(host) > 0 {
-				s, err := session.NewSession(&aws.Config{
-					Endpoint: aws.String(host),
-					LogLevel: aws.LogLevel(aws.LogDebugWithRequestErrors)})
+				s, err = session.NewSession(&aws.Config{
+					Endpoint:         aws.String(host),
+					S3ForcePathStyle: aws.Bool(true),
+					LogLevel:         aws.LogLevel(aws.LogDebugWithRequestErrors)})
 				if err != nil {
 					log.Fatal().Err(err).Msg("Create S3 Session")
 				}
 			} else {
-				s, err := session.NewSession(&aws.Config{
+				s, err = session.NewSession(&aws.Config{
 					LogLevel: aws.LogLevel(aws.LogDebugWithRequestErrors)})
 				if err != nil {
 					log.Fatal().Err(err).Msg("Create S3 Session")
@@ -507,7 +508,7 @@ func parseBucket(bucketURI string) (string, string, string, error) {
 	// s3://bucket or s3://bucket/
 	case "minio":
 		host = u.Host
-		bucketpath := strings.SplitN(u.Path, "/", 1)
+		bucketpath := strings.SplitN(u.Path[1:], "/", 2)
 		bucket = bucketpath[0]
 		key = bucketpath[1]
 


### PR DESCRIPTION
This PR adds a new scheme for the s3-bucket argument, `minio://`, which allows you to specify a custom endpoint for your s3 connection rather than using the AWS defaults.  This allows you to use S3-compatible storage systems such as [MinIO](https://min.io/).  

I am an extreme novice at Go programming, so if I've done anything weird here that might break other things, I apologize in advance.  I wanted to provide this as a proof of concept to indicate how easy it is to support third-party S3-compatible endpoints. 
 If this is close to mergable, please feel free to suggest any amendments.

