### PR TITLE
Add an informational-level check for LB with external policy "Cluster."

### DIFF
--- a/internal/issues/codes.go
+++ b/internal/issues/codes.go
@@ -299,7 +299,9 @@ codes:
   1106:
     message:  "No target ports match service port %s"
     severity: 3
-
+  1107:
+    message: "LoadBalancer detected but service sets ExternalTrafficPolicy: Cluster"
+    severity: 1
   # -------------------------------------------------------------------------
   # ReplicaSet
   1120:

--- a/internal/issues/codes_test.go
+++ b/internal/issues/codes_test.go
@@ -12,7 +12,7 @@ func TestCodesLoad(t *testing.T) {
 	cc, err := issues.LoadCodes()
 
 	assert.Nil(t, err)
-	assert.Equal(t, 79, len(cc.Glossary))
+	assert.Equal(t, 80, len(cc.Glossary))
 	assert.Equal(t, "No liveness probe", cc.Glossary[103].Message)
 	assert.Equal(t, config.WarnLevel, cc.Glossary[103].Severity)
 }

--- a/internal/sanitize/svc.go
+++ b/internal/sanitize/svc.go
@@ -53,6 +53,7 @@ func (s *Service) Sanitize(ctx context.Context) error {
 		s.checkPorts(ctx, svc.Namespace, svc.Spec.Selector, svc.Spec.Ports)
 		s.checkEndpoints(ctx, svc.Spec.Selector, svc.Spec.Type)
 		s.checkType(ctx, svc.Spec.Type)
+		s.checkExternalTrafficPolicy(ctx, svc.Spec.Type, svc.Spec.ExternalTrafficPolicy)
 
 		if s.NoConcerns(fqn) && s.Config.ExcludeFQN(internal.MustExtractSectionGVR(ctx), fqn) {
 			s.ClearOutcome(fqn)
@@ -96,6 +97,13 @@ func (s *Service) checkType(ctx context.Context, kind v1.ServiceType) {
 	}
 	if kind == v1.ServiceTypeNodePort {
 		s.AddCode(ctx, 1104)
+	}
+}
+func (s *Service) checkExternalTrafficPolicy(ctx context.Context, kind v1.ServiceType, policy v1.ServiceExternalTrafficPolicyType) {
+	if kind == v1.ServiceTypeLoadBalancer {
+		if policy == v1.ServiceExternalTrafficPolicyTypeCluster {
+			s.AddCode(ctx, 1107)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR will check that for any given Service of type LoadBalancer, if that Service has its ExternalTrafficPolicy set as "Cluster", it will call it out as an information-level message.

It is considered best practice that when using a LoadBalancer, that the services are configured as ExternalTrafficPolicy: Local, thereby reducing the possibility of additional hops inside of the Kubernetes cluster itself.  However, when the TrafficPolicy is set as Local, extra considerations must be addressed to ensure evenly-distributed traffic between nodes.

It is briefly mentioned in [this section of the docs about aws nlb.](https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support)