### PR TITLE
Issue a warning for the usage of NodePort Service with externalTrafficPolicy:Local

### DIFF
--- a/internal/issues/codes.go
+++ b/internal/issues/codes.go
@@ -299,6 +299,9 @@ codes:
   1106:
     message:  "No target ports match service port %s"
     severity: 3
+  1107:
+    message:  NodePort service with externalTrafficPolicy Local detected
+    severity: 2
 
   # -------------------------------------------------------------------------
   # ReplicaSet

--- a/internal/issues/codes_test.go
+++ b/internal/issues/codes_test.go
@@ -12,7 +12,7 @@ func TestCodesLoad(t *testing.T) {
 	cc, err := issues.LoadCodes()
 
 	assert.Nil(t, err)
-	assert.Equal(t, 79, len(cc.Glossary))
+	assert.Equal(t, 80, len(cc.Glossary))
 	assert.Equal(t, "No liveness probe", cc.Glossary[103].Message)
 	assert.Equal(t, config.WarnLevel, cc.Glossary[103].Severity)
 }

--- a/internal/sanitize/svc.go
+++ b/internal/sanitize/svc.go
@@ -53,6 +53,7 @@ func (s *Service) Sanitize(ctx context.Context) error {
 		s.checkPorts(ctx, svc.Namespace, svc.Spec.Selector, svc.Spec.Ports)
 		s.checkEndpoints(ctx, svc.Spec.Selector, svc.Spec.Type)
 		s.checkType(ctx, svc.Spec.Type)
+		s.checkTypeExternalTrafficPolicy(ctx, svc.Spec.Type, svc.Spec.ExternalTrafficPolicy)
 
 		if s.NoConcerns(fqn) && s.Config.ExcludeFQN(internal.MustExtractSectionGVR(ctx), fqn) {
 			s.ClearOutcome(fqn)
@@ -112,6 +113,13 @@ func (s *Service) checkEndpoints(ctx context.Context, sel map[string]string, kin
 	ep := s.GetEndpoints(internal.MustExtractFQN(ctx))
 	if ep == nil || len(ep.Subsets) == 0 {
 		s.AddCode(ctx, 1105)
+	}
+}
+
+// CheckTypeExternalTrafficPolicy runs a sanity check for inappropriate combinations of a service type and an external traffic policy
+func (s *Service) checkTypeExternalTrafficPolicy(ctx context.Context, kind v1.ServiceType, policy v1.ServiceExternalTrafficPolicyType) {
+	if kind == v1.ServiceTypeNodePort && policy == v1.ServiceExternalTrafficPolicyTypeLocal {
+		s.AddCode(ctx, 1107)
 	}
 }
 


### PR DESCRIPTION
### Changes

This pull request adds a sanitizer for Service which checks whether any NodePort Service sets the externalTrafficPolicy to Local instead of the default value, Cluster.

### Intention

`spec.externalTrafficPolicy: Local` is an option mainly used to eliminate redundant cross-node load balancing traffic when incoming traffic is already load-balanced by a load balancer outside the cluster. So, when the type of the Service is LoadBalancer, the usage of `spec.externalTrafficPolicy: Local` makes sense.

When the type of the Service is NodePort, however, specifying `spec.externalTrafficPolicy: Local` could make HTTP requests randomly fail. With NodePort Service, where all the nodes listen on the same port regardless of the inter-node distribution of Pods, even if incoming traffic reaches a node with no serving Pods, the traffic is then re-routed to another node with serving Pods when the externalTrafficPolicy is Cluster. When the externalTrafficPolicy is Local, this inter-node re-routing does not occur, and the request stalls.

For this reason, it is generally recommended to avoid the usage of Service Type=NodePort along with Local externalTrafficPolicy.


### Note

This change could be combined with PR #119.