### PR TITLE
Updated the image tag in cronjob.yml

### DIFF
--- a/k8s/popeye/cronjob.yml
+++ b/k8s/popeye/cronjob.yml
@@ -6,7 +6,7 @@ metadata:
   name: popeye
   namespace: popeye
 spec:
-  schedule: "*/2 * * * *"
+  schedule: "59 23 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/k8s/popeye/cronjob.yml
+++ b/k8s/popeye/cronjob.yml
@@ -6,7 +6,7 @@ metadata:
   name: popeye
   namespace: popeye
 spec:
-  schedule: "* */1 * * *"
+  schedule: "*/2 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -16,7 +16,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: popeye
-              image: quay.io/derailed/popeye:v0.3.6
+              image: quay.io/derailed/popeye:latest
               imagePullPolicy: IfNotPresent
               command: ["/bin/popeye"]
               args:


### PR DESCRIPTION
In the popeye:v0.3.6, image It is not accepting the s3 bucket argument in cronjob. It working fine in latest image.