### PR TITLE
Fix comment to reflect correct severity levels

### DIFF
--- a/spinach/spinach_aks.yml
+++ b/spinach/spinach_aks.yml
@@ -79,7 +79,7 @@ popeye:
     # Fail if more than 3 restarts on any pods
     restarts: 3
 
-  # Code specifies a custom severity level ie critical=1, warn=2, info=3
+  # Code specifies a custom severity level ie critical=3, warn=2, info=1
   codes:
     206:
       severity: 1

--- a/spinach/spinach_eks.yml
+++ b/spinach/spinach_eks.yml
@@ -83,7 +83,7 @@ popeye:
     # Fail if more than 3 restarts on any pods
     restarts: 3
 
-  # Code specifies a custom severity level ie critical=1, warn=2, info=3
+  # Code specifies a custom severity level ie critical=3, warn=2, info=1
   codes:
     206:
       severity: 1


### PR DESCRIPTION
By using the `severity:` config, I encountered that the values are actually interpreted the other way, i.e. 3 is critical, not 1.
If this is not intended, the logic needs be be adopted, since it is the current behaviour.