### PR TITLE
Add more documentation on excludes in SpinachYAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,17 +282,17 @@ popeye:
 
   # Excludes excludes certain resources from Popeye scans
   excludes:
-      v1/pods:
-      # In the monitoring namespace excludes all probes check on pod's containers.
-      - name: rx:monitoring
-        codes:
-        - 102
-      # Excludes all istio-proxy container scans for pods in the icx namespace.
-      - name: rx:icx/.*
-        containers:
-          # Excludes istio init/sidecar container from scan!
-          - istio-proxy
-          - istio-init
+    v1/pods:
+    # In the monitoring namespace excludes all probes check on pod's containers.
+    - name: rx:monitoring
+      codes:
+      - 102
+    # Excludes all istio-proxy container scans for pods in the icx namespace.
+    - name: rx:icx/.*
+      containers:
+        # Excludes istio init/sidecar container from scan!
+        - istio-proxy
+        - istio-init
     # ConfigMap sanitizer exclusions...
     v1/configmaps:
       # Excludes key must match the singular form of the resource.

--- a/README.md
+++ b/README.md
@@ -306,6 +306,9 @@ popeye:
           - 404
       # Exclude all istio* namespaces from being scanned.
       - name: rx:istio
+    # Completely exclude horizontal pod autoscalers.
+    autoscaling/v1/horizontalpodautoscalers:
+      - name: rx:.*
 
   # Configure node resources.
   node:

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ the container utilization threshold and specific sanitizer configurations as wel
 
 NOTE: This file will change as Popeye matures!
 
+Under the `excludes` key you can configure to skip certain resources, or certain checks by code. Here, resource types are indicated in a group/version/resource notation. Example: to exclude pod disruptions budgets, use the notation `policy/v1beta1/poddisruptionbudgets`. Note that the resource name is written in the plural form and everything is spelled in lowercase. For resources without an API group, the group part is omitted (Examples: `v1/pods`, `v1/services`, `v1/configmaps`).
+
 A resource is identified by a resource kind and a fully qualified resource name, i.e. `namespace/resource_name`.
 
 For example, the FQN of a pod named `fred-1234` in the namespace `blee` will be `blee/fred-1234`. This provides for differentiating `fred/p1` and `blee/p1`. For cluster wide resources, the FQN is equivalent to the name. Exclude rules can have either a straight string match or a regular expression. In the latter case the regular expression must be indicated using the `rx:` prefix.


### PR DESCRIPTION
Closes https://github.com/derailed/popeye/issues/129

This should help users understand faster and in a more complete way how excludes can be used.

Changes

- Adds a paragraph of explanation for the notation needed in excludes in SpinachYAML
- Aligns the indentation under `excludes` in the YAML example (2 blanks per level)
- Extends the YAML example to include `autoscaling/v1/horizontalpodautoscalers` as an example with full group/version/resource notation.

