### PR TITLE
Add check for the number of master nodes

### DIFF
--- a/internal/issues/codes.go
+++ b/internal/issues/codes.go
@@ -243,6 +243,9 @@ codes:
   711:
     message: Scheduling disabled
     severity: 2
+  712:
+    message: Found only one master node
+    severity: 1
 
   # -------------------------------------------------------------------------
   # Namespace

--- a/internal/issues/codes_test.go
+++ b/internal/issues/codes_test.go
@@ -12,7 +12,7 @@ func TestCodesLoad(t *testing.T) {
 	cc, err := issues.LoadCodes()
 
 	assert.Nil(t, err)
-	assert.Equal(t, 81, len(cc.Glossary))
+	assert.Equal(t, 82, len(cc.Glossary))
 	assert.Equal(t, "No liveness probe", cc.Glossary[103].Message)
 	assert.Equal(t, config.WarnLevel, cc.Glossary[103].Severity)
 }

--- a/internal/issues/collector.go
+++ b/internal/issues/collector.go
@@ -37,7 +37,7 @@ func (c *Collector) ClearOutcome(fqn string) {
 	delete(c.outcomes, fqn)
 }
 
-// NoConcerns returns true is scan is successful.
+// NoConcerns returns true if scan is successful.
 func (c *Collector) NoConcerns(fqn string) bool {
 	return len(c.outcomes[fqn]) == 0
 }

--- a/internal/sanitize/node.go
+++ b/internal/sanitize/node.go
@@ -10,6 +10,15 @@ import (
 	mv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
+const (
+	// Label for master nodes since v1.6
+	labelNodeRoleMaster = "node-role.kubernetes.io/master"
+
+	// Future label for master nodes as of v1.20,
+	// according to https://github.com/kubernetes/kubeadm/issues/2200
+	labelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
+)
+
 type (
 	tolerations map[string]struct{}
 
@@ -129,15 +138,14 @@ func (n *Node) checkConditions(ctx context.Context, no *v1.Node) bool {
 
 // checkMasterRole checks whether the node is a master node.
 func (n *Node) checkMasterRole(ctx context.Context, no *v1.Node) bool {
-	var isMaster bool = false
-
-	if role, ok := no.Labels["role"]; ok {
-		if role == "master" {
-			isMaster = true
-		}
+	if _, ok := no.Labels[labelNodeRoleMaster]; ok {
+		return true
+	}
+	if _, ok := no.Labels[labelNodeRoleControlPlane]; ok {
+		return true
 	}
 
-	return isMaster
+	return false
 }
 
 func (n *Node) statusReport(ctx context.Context, cond v1.NodeConditionType, status v1.ConditionStatus) bool {

--- a/internal/sanitize/node.go
+++ b/internal/sanitize/node.go
@@ -61,7 +61,7 @@ func (n *Node) Sanitize(ctx context.Context) error {
 	nmx := client.NodesMetrics{}
 	nodesMetrics(n.ListNodes(), n.ListNodesMetrics(), nmx)
 
-	numMasters := 0
+	var numMasters int
 
 	for fqn, no := range n.ListNodes() {
 		n.InitOutcome(fqn)

--- a/internal/sanitize/node.go
+++ b/internal/sanitize/node.go
@@ -51,9 +51,16 @@ func NewNode(co *issues.Collector, lister NodeLister) *Node {
 func (n *Node) Sanitize(ctx context.Context) error {
 	nmx := client.NodesMetrics{}
 	nodesMetrics(n.ListNodes(), n.ListNodesMetrics(), nmx)
+
+	numMasters := 0
+
 	for fqn, no := range n.ListNodes() {
 		n.InitOutcome(fqn)
 		ctx = internal.WithFQN(ctx, fqn)
+
+		if n.checkMasterRole(ctx, no) {
+			numMasters++
+		}
 
 		ready := n.checkConditions(ctx, no)
 		if ready {
@@ -64,6 +71,10 @@ func (n *Node) Sanitize(ctx context.Context) error {
 		if n.NoConcerns(fqn) && n.Config.ExcludeFQN(internal.MustExtractSectionGVR(ctx), fqn) {
 			n.ClearOutcome(fqn)
 		}
+	}
+
+	if numMasters == 1 {
+		n.AddCode(ctx, 712)
 	}
 
 	return nil
@@ -114,6 +125,19 @@ func (n *Node) checkConditions(ctx context.Context, no *v1.Node) bool {
 	}
 
 	return ready
+}
+
+// checkMasterRole checks whether the node is a master node.
+func (n *Node) checkMasterRole(ctx context.Context, no *v1.Node) bool {
+	var isMaster bool = false
+
+	if role, ok := no.Labels["role"]; ok {
+		if role == "master" {
+			isMaster = true
+		}
+	}
+
+	return isMaster
 }
 
 func (n *Node) statusReport(ctx context.Context, cond v1.NodeConditionType, status v1.ConditionStatus) bool {


### PR DESCRIPTION
Closes https://github.com/derailed/popeye/issues/136

This PR adds a check for the number of master nodes. If there is only a single one, an info is shown (severity: 1), since [multiple master nodes](https://kubernetes.io/docs/tasks/administer-cluster/highly-available-master/) are more resilient.

### Preview

With one master

![image](https://user-images.githubusercontent.com/273727/94677186-ca201580-031c-11eb-84e3-ce02b8eedec9.png)

With 3 masters

![image](https://user-images.githubusercontent.com/273727/94680783-9ba53900-0322-11eb-8ed4-cfc36e4181ac.png)

### Open tasks

- [ ] Verify that excluding this check by code works as expected.