### PR TITLE
Add check for pod being controlled by other resource

### DIFF
--- a/internal/issues/codes.go
+++ b/internal/issues/codes.go
@@ -111,6 +111,9 @@ codes:
   207:
     message:  Pod is in an unhappy phase (%s)
     severity: 3
+  208:
+    message:  Pod is not controlled by any resource (ReplicaSet etc.)
+    severity: 2
 
   # -------------------------------------------------------------------------
   # Security

--- a/internal/issues/codes_test.go
+++ b/internal/issues/codes_test.go
@@ -12,7 +12,7 @@ func TestCodesLoad(t *testing.T) {
 	cc, err := issues.LoadCodes()
 
 	assert.Nil(t, err)
-	assert.Equal(t, 81, len(cc.Glossary))
+	assert.Equal(t, 82, len(cc.Glossary))
 	assert.Equal(t, "No liveness probe", cc.Glossary[103].Message)
 	assert.Equal(t, config.WarnLevel, cc.Glossary[103].Severity)
 }

--- a/internal/sanitize/pod_test.go
+++ b/internal/sanitize/pod_test.go
@@ -95,7 +95,8 @@ func TestPodSanitize(t *testing.T) {
 							restarts: 0,
 							state:    running,
 						},
-						phase: v1.PodRunning,
+						phase:      v1.PodRunning,
+						controlled: true,
 					}),
 				},
 			}),
@@ -121,7 +122,7 @@ func TestPodSanitize(t *testing.T) {
 					}),
 				},
 			}),
-			1,
+			2,
 		},
 		"defaultSA": {
 			makePodLister(podOpts{
@@ -141,6 +142,7 @@ func TestPodSanitize(t *testing.T) {
 							restarts: 0,
 							state:    running,
 						},
+						controlled: true,
 					}),
 				},
 			}),
@@ -171,6 +173,7 @@ type (
 		pods        map[string]*v1.Pod
 		serviceAcct string
 		certs       bool
+		controlled  bool
 	}
 
 	pod struct {
@@ -286,6 +289,15 @@ func makeFullPod(opts podOpts) *v1.Pod {
 		po.Spec.ServiceAccountName = opts.serviceAcct
 	}
 	po.Spec.AutomountServiceAccountToken = &opts.certs
+
+	if opts.controlled {
+		truthful := true
+		po.OwnerReferences = append(po.OwnerReferences, metav1.OwnerReference{
+			Kind:       "ReplicaSet",
+			Name:       "mock-replica-set",
+			Controller: &truthful,
+		})
+	}
 
 	po.Status = v1.PodStatus{
 		Phase: opts.phase,


### PR DESCRIPTION
A pod that is not controlled by another resource is not resilient to nodes being terminated and other common cluster disruptions. Hence this PR adds a check with severity=2 to see whether a pod is controlled by any resource.

## Preview

![image](https://user-images.githubusercontent.com/273727/94687256-52f27d80-032c-11eb-8332-3da6deecc581.png)

The pod has been launched using this command:

```nohighlight
kubectl run marian-toolbox \
    --namespace marian \
    --stdin --tty \
    --restart Never \
    --rm \
    --image quay.io/marian/toolbox
```

## TODO

- Currently it looks as if I cannot exclude this check using this config:

```yaml
popeye:
  excludes:
    v1/pods:
      - name: rx:marian
        codes:
          - 208
```

Any advice would be welcome.