### PR TITLE
Add check for service having multiple endpoints

### DIFF
--- a/assets/codes.yml
+++ b/assets/codes.yml
@@ -225,6 +225,9 @@ codes:
   1105:
     message: No associated endpoints
     severity: 3
+  1109:
+    message: Only one associated endpoint
+    severity: 2
   # NetworkPolicies
   1200:
     message: No pods matches %s pod selector

--- a/internal/issues/codes.go
+++ b/internal/issues/codes.go
@@ -305,6 +305,9 @@ codes:
   1108:
     message:  NodePort detected but service sets externalTrafficPolicy to "Local"
     severity: 1
+  1109:
+    message: Only one associated endpoint
+    severity: 2
 
   # -------------------------------------------------------------------------
   # ReplicaSet

--- a/internal/sanitize/svc.go
+++ b/internal/sanitize/svc.go
@@ -123,6 +123,16 @@ func (s *Service) checkEndpoints(ctx context.Context, sel map[string]string, kin
 	ep := s.GetEndpoints(internal.MustExtractFQN(ctx))
 	if ep == nil || len(ep.Subsets) == 0 {
 		s.AddCode(ctx, 1105)
+	} else {
+		numEndpointAddresses := 0
+		for _, s := range ep.Subsets {
+			for range s.Addresses {
+				numEndpointAddresses++
+			}
+		}
+		if numEndpointAddresses < 2 {
+			s.AddCode(ctx, 1109)
+		}
 	}
 }
 


### PR DESCRIPTION
For the sake of resilience, it is recommendable to associate a service with more than one endpoint, so that the service can still operate while a single endpoint is not reachable.

This PR adds a check for services and emits a warning (severity 2) when a service has only one endpoint associated.