### PR TITLE
add a flag for switching non-zero exit status off

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,11 +365,17 @@ spec:
               args:
                 - -o
                 - yaml
+                - --force-exit-zero
+                - true
               resources:
                 limits:
                   cpu:    500m
                   memory: 100Mi
 ```
+
+The `--force-exit-zero` should be set to `true`. Otherwise, the pods will end up in an error state. Note that popeye
+exits with a non-zero error code if the report has any errors.
+
 
 ## Popeye got your RBAC!
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,10 @@ func doIt(cmd *cobra.Command, args []string) {
 		bomb(err.Error())
 	}
 
+	if flags.ForceExitZero != nil && *flags.ForceExitZero {
+		os.Exit(0)
+	}
+
 	if errCount > 0 {
 		os.Exit(1)
 	}
@@ -250,6 +254,14 @@ func initFlags() {
 		"pushgateway-address",
 		"",
 		"Address of pushgateway e.g. http://localhost:9091",
+	)
+
+	rootCmd.Flags().BoolVarP(
+		flags.ForceExitZero,
+		"force-exit-zero",
+		"",
+		false,
+		"Force zero exit status when report errors are present",
 	)
 }
 

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -22,6 +22,7 @@ type Flags struct {
 	InClusterName      *string
 	StandAlone         bool
 	ActiveNamespace    *string
+	ForceExitZero      *bool
 }
 
 // NewFlags returns new configuration flags.
@@ -40,6 +41,7 @@ func NewFlags() *Flags {
 		Sections:           &[]string{},
 		ConfigFlags:        genericclioptions.NewConfigFlags(false),
 		PushGatewayAddress: strPtr(""),
+		ForceExitZero:		boolPtr(false),
 	}
 }
 


### PR DESCRIPTION
In version 0.8.9, popeye was changed to return a non-zero exit status if the report has any errors. While this is helpful for stopping CI/CD pipelines, it broke the functionality of running popeye as a CronJob. When run as a CronJob and the report has errors, the pod results in an error state and lingers around. 

This pull request makes the non-zero exit status as an optional feature. I have added a new flag `--error-status-on-fail`. It defaults to `true`. When set to false, popeye always returns a zero exit status.

More on the issue discussed here: https://github.com/derailed/popeye/issues/122