### PR TITLE
fix pod reporting when some containers are excluded

### DIFF
--- a/internal/sanitize/pod_test.go
+++ b/internal/sanitize/pod_test.go
@@ -67,7 +67,7 @@ func TestPodCheckSecure(t *testing.T) {
 		t.Run(k, func(t *testing.T) {
 			p := NewPod(issues.NewCollector(loadCodes(t), makeConfig(t)), nil)
 
-			p.checkSecure(ctx, u.pod.Spec)
+			p.checkSecure(ctx, "default/p1", u.pod.Spec)
 			assert.Equal(t, u.issues, len(p.Outcome()["default/p1"]))
 		})
 	}

--- a/pkg/config/excludes.go
+++ b/pkg/config/excludes.go
@@ -91,7 +91,7 @@ func (e Excludes) ShouldExclude(section, fqn string, code ID) bool {
 // Match checks if a given named should be excluded.
 func (e Exclusions) Match(resource string, code ID) bool {
 	for _, exclude := range e {
-		if exclude.Match(resource) && hasCode(exclude.Codes, code) {
+		if len(exclude.Containers) == 0 && exclude.Match(resource) && hasCode(exclude.Codes, code) {
 			return true
 		}
 	}


### PR DESCRIPTION
When individual pod containers are excluded in configuration, the remaining included containers in matching pods get scanned, but their results are not recorded because the pod name matches the name used in the configuration. The fixes in this patch remedy that situation by excluding the pods by name only when exclude configuration for that pod has zero containers specified. 
This assumes that if a user wants the pod totally excluded, no containers would be specified in the pod exclude configuration. 