### PR TITLE
Add check for pods that are managed by multiple pdbs

### DIFF
--- a/internal/issues/assets/codes.yml
+++ b/internal/issues/assets/codes.yml
@@ -71,6 +71,9 @@ codes:
   208:
     message: Unmanaged pod detected. Best to use a controller
     severity: 2
+  209:
+    message: Pod is managed by multiple PodDisruptionBudgets (%s)
+    severity: 2
 
   # Security
   300:

--- a/internal/issues/codes_test.go
+++ b/internal/issues/codes_test.go
@@ -12,7 +12,7 @@ func TestCodesLoad(t *testing.T) {
 	cc, err := issues.LoadCodes()
 
 	assert.Nil(t, err)
-	assert.Equal(t, 85, len(cc.Glossary))
+	assert.Equal(t, 86, len(cc.Glossary))
 	assert.Equal(t, "No liveness probe", cc.Glossary[103].Message)
 	assert.Equal(t, config.WarnLevel, cc.Glossary[103].Severity)
 }

--- a/internal/sanitize/pod_test.go
+++ b/internal/sanitize/pod_test.go
@@ -1,6 +1,7 @@
 package sanitize
 
 import (
+	"context"
 	"testing"
 
 	"github.com/derailed/popeye/internal"
@@ -393,5 +394,180 @@ func makeSecPod(pod, init, co1, co2 NonRootUser) v1.Pod {
 			},
 			SecurityContext: &secCtx,
 		},
+	}
+}
+
+func TestPodCheckForMultiplePdbMatches(t *testing.T) {
+	type fields struct {
+		Collector   *issues.Collector
+		PodMXLister PodMXLister
+	}
+	type args struct {
+		ctx          context.Context
+		podLabels    map[string]string
+		podNamespace string
+		pdbs         map[string]*polv1beta1.PodDisruptionBudget
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   issues.Issues
+	}{
+		{
+			name: "pod with one label - two pdb matches",
+			args: args{
+				podNamespace: "namespace-1",
+				podLabels:    map[string]string{"app": "test"},
+				pdbs: map[string]*polv1beta1.PodDisruptionBudget{
+					"pdb": {
+						Spec: polv1beta1.PodDisruptionBudgetSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pdb-1",
+							Namespace: "namespace-1",
+						},
+					},
+					"pdb2": {
+						Spec: polv1beta1.PodDisruptionBudgetSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pdb-2",
+							Namespace: "namespace-1",
+						},
+					},
+				},
+			},
+			want: issues.Issues{
+				issues.Issue{
+					GVR:     "v1/pods",
+					Group:   "__root__",
+					Level:   2,
+					Message: "[POP-209] Pod is managed by multiple PodDisruptionBudgets (pdb-1, pdb-2)"},
+			},
+		},
+		{
+			name: "pod with one label - three pdbs - only two in pod namespace - expecting two matches",
+			args: args{
+				podNamespace: "namespace-1",
+				podLabels:    map[string]string{"app": "test"},
+				pdbs: map[string]*polv1beta1.PodDisruptionBudget{
+					"pdb": {
+						Spec: polv1beta1.PodDisruptionBudgetSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pdb-1",
+							Namespace: "namespace-1",
+						},
+					},
+					"pdb2": {
+						Spec: polv1beta1.PodDisruptionBudgetSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pdb-2",
+							Namespace: "namespace-1",
+						},
+					},
+					"pdb3": {
+						Spec: polv1beta1.PodDisruptionBudgetSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pdb-3",
+							Namespace: "namespace-2",
+						},
+					},
+				},
+			},
+			want: issues.Issues{
+				issues.Issue{
+					GVR:     "v1/pods",
+					Group:   "__root__",
+					Level:   2,
+					Message: "[POP-209] Pod is managed by multiple PodDisruptionBudgets (pdb-1, pdb-2)"},
+			},
+		},
+		{
+			name: "one pdb match, no issue expected",
+			args: args{
+				podNamespace: "namespace-1",
+				podLabels:    map[string]string{"app": "test", "app2": "test2"},
+				pdbs: map[string]*polv1beta1.PodDisruptionBudget{
+					"pdb": {
+						Spec: polv1beta1.PodDisruptionBudgetSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test", "app2": "test2"},
+							},
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pdb-1",
+							Namespace: "namespace-1",
+						},
+					},
+					"pdb2": {
+						Spec: polv1beta1.PodDisruptionBudgetSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app3": "test3"},
+							},
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pdb-2",
+							Namespace: "namespace-1",
+						},
+					},
+				},
+			},
+			want: issues.Issues(nil),
+		},
+		{
+			name: "pod with no label - no issue expected",
+			args: args{
+				podLabels: map[string]string{},
+				pdbs: map[string]*polv1beta1.PodDisruptionBudget{
+					"pdb": {
+						Spec: polv1beta1.PodDisruptionBudgetSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pdb-1"},
+					},
+					"pdb2": {
+						Spec: polv1beta1.PodDisruptionBudgetSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pdb-2"},
+					},
+				},
+			},
+			want: issues.Issues(nil),
+		},
+	}
+	ctx := makeContext("v1/pods", "po")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPod(issues.NewCollector(loadCodes(t), makeConfig(t)), tt.fields.PodMXLister)
+
+			p.checkForMultiplePdbMatches(ctx, tt.args.podNamespace, tt.args.podLabels, tt.args.pdbs)
+			assert.Equal(t, tt.want, p.Outcome()[""])
+		})
 	}
 }


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds a new check with code `209` for the sanitizer `pod.go`. In Kubernetes it is possible to have multiple `PodDisruptionBudgets` to match on one Pod via `spec.Selector.MatchLabels`. A pod should always be managed by only one PodDisruptionBudget. If a pod is managed by multiple PodDisruptionBudgets, the eviction API will disallow eviction of that pod. This leads to node drains being interrupted or blocked. For reference, [check here](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#arbitrary-controllers-and-selectors). 

With this check in place, `popeye` will show an additional issue on pod sanitizers with the severity level of `Warning (2)`

Testing declaration: Some new tests were added to `pod_test.go` in order to validate the funcionality. All other tests continue to work with no issues.

Example:
```
PODS (1 SCANNED)                                                               💥 0 😱 1 🔊 0 ✅ 0 0٪
┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅

test-namespace/test-pod-7567d9fdc9-k5xpv.............................................😱
    😱 [POP-209] Pod is managed by multiple PodDisruptionBudgets (pdb-one, pdb-two).
```


For context:

At Mercedes-Benz, our team is running a Container-as-a-Service (CaaS) platform based on Kubernetes.
We recently built a new feature to check for cluster misconfigurations and bad practices, which is partly based on popeye.

<sub> Tayfun Yalcin <tayfun.yalcin@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)</sub>
