### PR TITLE
Add go install option to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Popeye is available on Linux, OSX and Windows platforms.
    ```shell
    brew install derailed/popeye/popeye
    ```
+* Using `go install`
+ 
+ ```shell
+ go install github.com/derailed/popeye@latest
+ ```
 
 * Building from source
    Popeye was built using go 1.12+. In order to build Popeye from source you must:

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Popeye is available on Linux, OSX and Windows platforms.
    ```
 * Using `go install`
  
- ```shell
- go install github.com/derailed/popeye@latest
- ```
+    ```shell
+    go install github.com/derailed/popeye@latest
+    ```
 
 * Building from source
    Popeye was built using go 1.12+. In order to build Popeye from source you must:


### PR DESCRIPTION
`go install` is an easier installation mechanism than building manually
for devs who have the golang toolchain installed.

Hence, add that to the readme.