### PR TITLE
📦 Add arm64 Darwin releases to krew-index

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -29,6 +29,12 @@ spec:
       bin: kubectl-popeye
     - selector:
         matchLabels:
+          os: darwin
+          arch: arm64
+      {{ addURIAndSha "https://github.com/derailed/popeye/releases/download/{{ .TagName }}/popeye_Darwin_arm64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-popeye
+    - selector:
+        matchLabels:
           os: linux
           arch: amd64
       {{ addURIAndSha "https://github.com/derailed/popeye/releases/download/{{ .TagName }}/popeye_Linux_x86_64.tar.gz" .TagName }}


### PR DESCRIPTION
These changes update the `.krew.yaml` file used to publish new versions of popeye to the krew-index to include artifacts for arm64 machines running macOS (Darwin). As a result of these changes, developers using Apple Silicon devices will be able to install popeye using `brew`.

Fixes #221