### PR TITLE
add a non-root user in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,7 @@ FROM alpine:3.14.0
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /popeye/execs/popeye /bin/popeye
 
+RUN adduser -u 5000 -D nonroot
+USER 5000
+
 ENTRYPOINT [ "/bin/popeye" ]


### PR DESCRIPTION
This PR updates the Dockerfile to add a non-root user in docker image.

With these changes we'll be able to run `popeye` in a Kubernetes cluster with the recommended `securityContext` configuration.

Example:
```yaml
cat << EOF | kubectl apply -f -
apiVersion: batch/v1
kind: Job
metadata:
  name: popeye
spec:
  template:
    spec:
      containers:
        - name: popeye
          image: derailed/popeye:latest
          args: [version]
          securityContext:
            runAsNonRoot: true    # <---------- HERE
      restartPolicy: Never
  backoffLimit: 0
EOF
```

Without these changes, the following error occurs:
```
Error: container has runAsNonRoot and image will run as root (pod: "popeye-qm5rm_default(38777aa3-6e21-4689-a1f7-6711bb3b0368)", container: popeye)
```