### PR TITLE
invalid value for --force-exit-zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,14 +381,13 @@ spec:
                 - -o
                 - yaml
                 - --force-exit-zero
-                - true
               resources:
                 limits:
                   cpu:    500m
                   memory: 100Mi
 ```
 
-The `--force-exit-zero` should be set to `true`. Otherwise, the pods will end up in an error state. Note that popeye
+The `--force-exit-zero` should be set. Otherwise, the pods will end up in an error state. Note that popeye
 exits with a non-zero error code if the report has any errors.
 
 


### PR DESCRIPTION
--force-exit-zero It is a parameter that does not accept values, you must simply indicate --foce-exit-zero without "true"