### PR TITLE
Reporting POP-402 issue

### DIFF
--- a/docs/codes.md
+++ b/docs/codes.md
@@ -57,7 +57,7 @@
 | ---------- | ----------------------------------------------------------- | -------- | ---------------- |
 | 400        | Used? Unable to locate resource reference                   | 1        |                  |
 | 401        | Key "%s" used? Unable to locate key reference               | 1        |                  |
-| 402        | No metric-server detected %v                                | 1        |                  |
+| 402        | No metrics-server detected                                  | 1        |                  |
 | 403        | Deprecated %s API group "%s". Use "%s" instead              | 2        |                  |
 | 404        | Deprecation check failed. %v                                | 1        |                  |
 | 405        | Is this a jurassic cluster? Might want to upgrade K8s a bit | 2        |                  |

--- a/internal/issues/assets/codes.yml
+++ b/internal/issues/assets/codes.yml
@@ -106,7 +106,7 @@ codes:
     message: Key "%s" used? Unable to locate key reference
     severity: 1
   402:
-    message: No metric-server detected %v
+    message: No metrics-server detected
     severity: 1
   403:
     message: Deprecated %s API group "%s". Use "%s" instead

--- a/internal/sanitize/cluster.go
+++ b/internal/sanitize/cluster.go
@@ -23,6 +23,7 @@ type (
 	// ClusterLister list available Clusters on a cluster.
 	ClusterLister interface {
 		ListVersion() (string, string)
+		HasMetrics() bool
 	}
 )
 
@@ -36,6 +37,21 @@ func NewCluster(co *issues.Collector, lister ClusterLister) *Cluster {
 
 // Sanitize cleanse the resource.
 func (c *Cluster) Sanitize(ctx context.Context) error {
+	if err := c.checkVersion(ctx); err != nil {
+		return err
+	}
+	c.checkMetricsServer(ctx)
+	return nil
+}
+
+func (c *Cluster) checkMetricsServer(ctx context.Context) {
+	ctx = internal.WithFQN(ctx, "Metrics")
+	if !c.HasMetrics() {
+		c.AddCode(ctx, 402)
+	}
+}
+
+func (c *Cluster) checkVersion(ctx context.Context) error {
 	major, minor := c.ListVersion()
 
 	m, err := strconv.Atoi(major)

--- a/internal/sanitize/cluster.go
+++ b/internal/sanitize/cluster.go
@@ -37,10 +37,10 @@ func NewCluster(co *issues.Collector, lister ClusterLister) *Cluster {
 
 // Sanitize cleanse the resource.
 func (c *Cluster) Sanitize(ctx context.Context) error {
+	c.checkMetricsServer(ctx)
 	if err := c.checkVersion(ctx); err != nil {
 		return err
 	}
-	c.checkMetricsServer(ctx)
 	return nil
 }
 

--- a/internal/scrub/cluster.go
+++ b/internal/scrub/cluster.go
@@ -40,3 +40,7 @@ func NewCluster(ctx context.Context, c *Cache, codes *issues.Codes) Sanitizer {
 func (d *Cluster) Sanitize(ctx context.Context) error {
 	return sanitize.NewCluster(d.Collector, d).Sanitize(ctx)
 }
+
+func (d *Cluster) HasMetrics() bool {
+	return d.client.HasMetrics()
+}

--- a/internal/scrub/cr.go
+++ b/internal/scrub/cr.go
@@ -23,29 +23,29 @@ type ClusterRole struct {
 
 // NewClusterRole return a new ClusterRole scruber.
 func NewClusterRole(ctx context.Context, c *Cache, codes *issues.Codes) Sanitizer {
-	crb := ClusterRole{
+	cr := ClusterRole{
 		client:    c.factory.Client(),
 		Config:    c.config,
 		Collector: issues.NewCollector(codes, c.config),
 	}
 
 	var err error
-	crb.ClusterRole, err = c.clusterroles()
+	cr.ClusterRole, err = c.clusterroles()
 	if err != nil {
-		crb.AddErr(ctx, err)
+		cr.AddErr(ctx, err)
 	}
 
-	crb.ClusterRoleBinding, err = c.clusterrolebindings()
+	cr.ClusterRoleBinding, err = c.clusterrolebindings()
 	if err != nil {
-		crb.AddCode(ctx, 402, err)
+		cr.AddErr(ctx, err)
 	}
 
-	crb.RoleBinding, err = c.rolebindings()
+	cr.RoleBinding, err = c.rolebindings()
 	if err != nil {
-		crb.AddErr(ctx, err)
+		cr.AddErr(ctx, err)
 	}
 
-	return &crb
+	return &cr
 }
 
 // Sanitize all available ClusterRoles.

--- a/internal/scrub/crb.go
+++ b/internal/scrub/crb.go
@@ -37,7 +37,7 @@ func NewClusterRoleBinding(ctx context.Context, c *Cache, codes *issues.Codes) S
 
 	crb.ClusterRole, err = c.clusterroles()
 	if err != nil {
-		crb.AddCode(ctx, 402, err)
+		crb.AddErr(ctx, err)
 	}
 
 	crb.Role, err = c.roles()

--- a/internal/scrub/hpa.go
+++ b/internal/scrub/hpa.go
@@ -67,7 +67,7 @@ func NewHorizontalPodAutoscaler(ctx context.Context, c *Cache, codes *issues.Cod
 
 	h.Node, err = c.nodes()
 	if err != nil {
-		h.AddCode(ctx, 402, err)
+		h.AddErr(ctx, err)
 	}
 
 	h.NodesMetrics, _ = c.nodesMx()

--- a/internal/scrub/np.go
+++ b/internal/scrub/np.go
@@ -37,7 +37,7 @@ func NewNetworkPolicy(ctx context.Context, c *Cache, codes *issues.Codes) Saniti
 
 	n.Namespace, err = c.namespaces()
 	if err != nil {
-		n.AddCode(ctx, 402, err)
+		n.AddErr(ctx, err)
 	}
 
 	n.Pod, err = c.pods()

--- a/internal/scrub/rb.go
+++ b/internal/scrub/rb.go
@@ -23,29 +23,29 @@ type RoleBinding struct {
 
 // NewRoleBinding return a new RoleBinding scruber.
 func NewRoleBinding(ctx context.Context, c *Cache, codes *issues.Codes) Sanitizer {
-	crb := RoleBinding{
+	rb := RoleBinding{
 		client:    c.factory.Client(),
 		Config:    c.config,
 		Collector: issues.NewCollector(codes, c.config),
 	}
 
 	var err error
-	crb.RoleBinding, err = c.rolebindings()
+	rb.RoleBinding, err = c.rolebindings()
 	if err != nil {
-		crb.AddErr(ctx, err)
+		rb.AddErr(ctx, err)
 	}
 
-	crb.ClusterRole, err = c.clusterroles()
+	rb.ClusterRole, err = c.clusterroles()
 	if err != nil {
-		crb.AddCode(ctx, 402, err)
+		rb.AddErr(ctx, err)
 	}
 
-	crb.Role, err = c.roles()
+	rb.Role, err = c.roles()
 	if err != nil {
-		crb.AddErr(ctx, err)
+		rb.AddErr(ctx, err)
 	}
 
-	return &crb
+	return &rb
 }
 
 // Sanitize all available RoleBindings.

--- a/internal/scrub/ro.go
+++ b/internal/scrub/ro.go
@@ -23,29 +23,29 @@ type Role struct {
 
 // NewRole return a new Role scruber.
 func NewRole(ctx context.Context, c *Cache, codes *issues.Codes) Sanitizer {
-	crb := Role{
+	ro := Role{
 		client:    c.factory.Client(),
 		Config:    c.config,
 		Collector: issues.NewCollector(codes, c.config),
 	}
 
 	var err error
-	crb.Role, err = c.roles()
+	ro.Role, err = c.roles()
 	if err != nil {
-		crb.AddErr(ctx, err)
+		ro.AddErr(ctx, err)
 	}
 
-	crb.ClusterRoleBinding, err = c.clusterrolebindings()
+	ro.ClusterRoleBinding, err = c.clusterrolebindings()
 	if err != nil {
-		crb.AddCode(ctx, 402, err)
+		ro.AddErr(ctx, err)
 	}
 
-	crb.RoleBinding, err = c.rolebindings()
+	ro.RoleBinding, err = c.rolebindings()
 	if err != nil {
-		crb.AddErr(ctx, err)
+		ro.AddErr(ctx, err)
 	}
 
-	return &crb
+	return &ro
 }
 
 // Sanitize all available Roles.


### PR DESCRIPTION
## Description
- Reporting the issue `[POP-402] No metrics-server detected`
- Fix unexpected output when popeye cannot list RBAC resources

## Linked Issues
Fixes https://github.com/derailed/popeye/issues/255 
Fixes https://github.com/derailed/popeye/issues/254

## How has this been tested?
As described in the following issues:
- https://github.com/derailed/popeye/issues/255 
```
go run main.go -o json | jq . | grep 402
              "message": "[POP-402] No metrics-server detected"
```
- https://github.com/derailed/popeye/issues/254
```
go run main.go --kubeconfig popeye-kubeconfig.yml
```
![image](https://user-images.githubusercontent.com/16636449/228053281-fa2b2a6a-0d08-487f-b0dc-e5cdbf5d25c0.png)

