### PR TITLE
Docker images via Goreleaser

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,40 @@
+name: goreleaser
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  packages: write
+  issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: stable
+      # More assembly might be required: Docker logins, GPG, etc. It all depends
+      # on your needs.
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro':
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -15,21 +15,29 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - run: git fetch --force --tags
+
       - uses: actions/setup-go@v4
         with:
           go-version: stable
-      # More assembly might be required: Docker logins, GPG, etc. It all depends
-      # on your needs.
+
       - uses: goreleaser/goreleaser-action@v4
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,14 +23,14 @@ builds:
       - -s -w -X github.com/derailed/popeye/cmd.version={{.Version}} -X github.com/derailed/popeye/cmd.commit={{.Commit}} -X github.com/derailed/popeye/cmd.date={{.Date}}
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      bit: Arm
-      bitv6: Arm6
-      bitv7: Arm7
-      amd64: x86_64
+    # replacements:
+    #   darwin: Darwin
+    #   linux: Linux
+    #   windows: Windows
+    #   bit: Arm
+    #   bitv6: Arm6
+    #   bitv7: Arm7
+    #   amd64: x86_64
 checksum:
   name_template: "checksums.txt"
 snapshot:
@@ -43,16 +43,27 @@ changelog:
       - "^test:"
 
 # Homebrew
-brews:
-  - name: popeye
-    tap:
-      owner: derailed
-      name: popeye-homebrew-tap
-    commit_author:
-      name: derailed
-      email: fernand@imhotep.io
-    folder: Formula
-    homepage: https://imhotep.io/popeye
-    description: A Kubernetes Cluster sanitizer and linter.
-    test: |
-      system "popeye version"
+# brews:
+#   - name: popeye
+#     tap:
+#       owner: derailed
+#       name: popeye-homebrew-tap
+#     commit_author:
+#       name: derailed
+#       email: fernand@imhotep.io
+#     folder: Formula
+#     homepage: https://imhotep.io/popeye
+#     description: A Kubernetes Cluster sanitizer and linter.
+#     test: |
+#       system "popeye version"
+
+dockers:
+  - image_templates:
+      - "ghcr.io/macmiranda/popeye:{{.Tag}}"
+      - "ghcr.io/macmiranda/popeye:latest"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,6 +89,7 @@ dockers:
       - "--label=org.opencontainers.image.description=A Kubernetes cluster resource sanitizer"
       - "--platform=linux/arm64/v8"
     use: buildx
+    goarch: arm64
     dockerfile: Dockerfile
 
 docker_manifests:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,11 +12,11 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - darwin
-      - windows
+      # - darwin
+      # - windows
     goarch:
       - amd64
-      - arm
+      # - arm
       - arm64
     goarm:
       - "7"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,12 @@
 project_name: popeye
+
 before:
   hooks:
     - go mod download
+
 release:
-  prerelease: false
+  prerelease: "false"
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -16,11 +19,12 @@ builds:
       - arm
       - arm64
     goarm:
-      - 7
+      - "7"
     flags:
       - -trimpath
     ldflags:
       - -s -w -X github.com/derailed/popeye/cmd.version={{.Version}} -X github.com/derailed/popeye/cmd.commit={{.Commit}} -X github.com/derailed/popeye/cmd.date={{.Date}}
+
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     # replacements:
@@ -31,10 +35,13 @@ archives:
     #   bitv6: Arm6
     #   bitv7: Arm7
     #   amd64: x86_64
+
 checksum:
   name_template: "checksums.txt"
+
 snapshot:
   name_template: "{{ .Tag }}-next"
+
 changelog:
   sort: asc
   filters:
@@ -59,11 +66,33 @@ changelog:
 
 dockers:
   - image_templates:
-      - "ghcr.io/macmiranda/popeye:{{.Tag}}"
-      - "ghcr.io/macmiranda/popeye:latest"
+      - "ghcr.io/macmiranda/popeye:{{.Version}}-amd64"
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.description=A Kubernetes cluster resource sanitizer"
+      - "--platform=linux/amd64"
+    use: buildx
+    dockerfile: Dockerfile
+
+  - image_templates:
+      - "ghcr.io/macmiranda/popeye:{{.Version}}-arm64v8"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.description=A Kubernetes cluster resource sanitizer"
+      - "--platform=linux/arm64/v8"
+    use: buildx
+    dockerfile: Dockerfile
+
+docker_manifests:
+- name_template: "ghcr.io/macmiranda/popeye:{{ .Version }}"
+  image_templates:
+  - "ghcr.io/macmiranda/popeye:{{ .Version }}-amd64"
+  - "ghcr.io/macmiranda/popeye:{{ .Version }}-arm64v8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,3 @@
-# -----------------------------------------------------------------------------
-# Build...
-FROM golang:1.18.1-alpine3.14 AS build
-
-WORKDIR /popeye
-
-COPY go.mod go.sum main.go Makefile ./
-COPY internal internal
-COPY cmd cmd
-COPY types types
-COPY pkg pkg
-RUN apk --no-cache add make git gcc libc-dev curl ca-certificates && make build
-
-# -----------------------------------------------------------------------------
-# Image...
-FROM alpine:3.14.0
-
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /popeye/execs/popeye /bin/popeye
-
-RUN adduser -u 5000 -D nonroot
-USER 5000
-
-ENTRYPOINT [ "/bin/popeye" ]
+FROM scratch
+ENTRYPOINT ["/popeye"]
+COPY popeye /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM scratch
 ENTRYPOINT ["/popeye"]
 COPY popeye /
+COPY --from=alpine:3.18.3 tmp/ /tmp/


### PR DESCRIPTION
I do realize this is not a mergeable pull request. It's more of an idea of how you could implement multi-arch builds using `goreleaser`

I added a GitHub workflow to create the release and attach the build artifacts as well as publish docker images to ghcr.io

It does reuse the built artifacts and just adds them to a `scratch` image. I had to add an extra step to create the `/tmp` folder since that's a requirement for the program to run.

I've disabled mac and windows builds just because I have no use for them.

Fixes https://github.com/derailed/popeye/issues/253