### PR TITLE
fix: "No resource meta found for networking.k8s.io/v1/ingresses" when…

### DIFF
--- a/pkg/popeye.go
+++ b/pkg/popeye.go
@@ -140,7 +140,7 @@ func (p *Popeye) scannedGVRs(rev *client.Revision) internal.GVRs {
 		internal.HpaGVR: "autoscaling/v2/horizontalpodautoscalers",
 	}
 
-	if rev.Minor < 18 {
+	if rev.Minor <= 18 {
 		mm[internal.IngGVR] = "networking.k8s.io/v1beta1/ingresses"
 	}
 	if rev.Minor < 21 {


### PR DESCRIPTION
ingress gvr compatibility error.
k8s server version.Minor == 18 
```bash
.kube|⇒ kubectl --kubeconfig deployment version
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"1", Minor:"27", GitVersion:"v1.27.3", GitCommit:"25b4e43193bcda6c7328a6d147b1fb73a33f1598", GitTreeState:"clean", BuildDate:"2023-06-14T09:53:42Z", GoVersion:"go1.20.5", Compiler:"gc", Platform:"darwin/amd64"}
Kustomize Version: v5.0.1
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.9", GitCommit:"94f372e501c973a7fa9eb40ec9ebd2fe7ca69848", GitTreeState:"clean", BuildDate:"2020-09-16T13:47:43Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"linux/amd64"}
WARNING: version difference between client (1.27) and server (1.18) exceeds the supported minor version skew of +/-1
.kube|⇒ 
.kube|⇒ kubectl --kubeconfig deployment -n cloudide api-resources | grep ingress
ingresses                          ing          extensions/v1beta1                true         Ingress
ingressclasses                                  networking.k8s.io/v1beta1         false        IngressClass
ingresses                          ing          networking.k8s.io/v1beta1         true         Ingress
```
run command error
```bash
popeye|master ⇒ go run main.go --kubeconfig ~/.kube/banana -n test     
 ___     ___ _____   _____                       D          .-'-.     
| _ \___| _ \ __\ \ / / __|                       O     __| K    `\  
|  _/ _ \  _/ _| \ V /| _|                         H   `-,-`--._   `\
|_| \___/_| |___| |_| |___|                       []  .->'  X     `|-'
  Biffs`em and Buffs`em!                            `=/ (__/_       /  
                                                      \_,    `    _)  
                                                         `----;  |     


Boom! No resource meta found for networking.k8s.io/v1/ingresses
exit status 1

```
see [https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md)