### PR TITLE
Multi-platform docker image support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk --no-cache add make git gcc libc-dev curl ca-certificates binutils-gold 
 
 # -----------------------------------------------------------------------------
 # Image...
-FROM alpine:3.19.0
+FROM alpine:3.19.1
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /popeye/execs/popeye /bin/popeye

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # -----------------------------------------------------------------------------
 # Build...
 FROM golang:1.21-alpine3.19 AS build
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /popeye
 
@@ -9,7 +11,8 @@ COPY internal internal
 COPY cmd cmd
 COPY types types
 COPY pkg pkg
-RUN apk --no-cache add make git gcc libc-dev curl ca-certificates binutils-gold && make build
+RUN apk --no-cache add make git gcc libc-dev curl ca-certificates binutils-gold && \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build
 
 # -----------------------------------------------------------------------------
 # Image...

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ VERSION  := v0.11.3
 GIT      := $(shell git rev-parse --short HEAD)
 DATE     := $(shell date +%FT%T%Z)
 IMG_NAME := derailed/popeye
-IMAGE    := ${IMG_NAME}:${VERSION}
+IMAGE    ?= ${IMG_NAME}:${VERSION}
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 
 default: help
 
@@ -25,6 +26,15 @@ img:  ## Build Docker Image
 
 push: img ## Push Docker Image
 	@docker push ${IMAGE}
+
+buildx: ## Build and push docker image for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name popeye-builder
+	docker buildx use popeye-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMAGE} -f Dockerfile.cross .
+	- docker buildx rm popeye-builder
+	rm Dockerfile.cross
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[38;5;69m%-30s\033[38;5;38m %s\033[0m\n", $$1, $$2}'


### PR DESCRIPTION
These changes add support for building multi-platform docker images, through the `make buildx` command, and bump alpine base image version.

This is how [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) generates the Makefile for generated-projects.

Closes: https://github.com/derailed/popeye/issues/253

I've built the image `ghcr.io/undistro/popeye:v0.11.3` with these changes. See the supported architectures:

![image](https://github.com/derailed/popeye/assets/16636449/5e310497-00c7-49ed-8773-a1bfdadc126c)


```shell
trivy image ghcr.io/undistro/popeye:v0.11.3 

2024-02-09T11:16:34.624-0300    INFO    Vulnerability scanning is enabled
2024-02-09T11:16:34.624-0300    INFO    Secret scanning is enabled
2024-02-09T11:16:34.624-0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-02-09T11:16:34.624-0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-02-09T11:16:36.410-0300    INFO    Detected OS: alpine
2024-02-09T11:16:36.410-0300    WARN    This OS version is not on the EOL list: alpine 3.19
2024-02-09T11:16:36.410-0300    INFO    Detecting Alpine vulnerabilities...
2024-02-09T11:16:36.413-0300    INFO    Number of language-specific files: 1
2024-02-09T11:16:36.414-0300    INFO    Detecting gobinary vulnerabilities...

ghcr.io/undistro/popeye:v0.11.3 (alpine 3.19.1)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```