### PR TITLE
Add support for ClusterRule aggregationRule

### DIFF
--- a/internal/cache/cr.go
+++ b/internal/cache/cr.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Popeye
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/derailed/popeye/internal"
+	"github.com/derailed/popeye/internal/db"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ClusterRole represents ClusterRole cache.
+type ClusterRole struct {
+	db *db.DB
+}
+
+// NewClusterRole returns a new ClusterRole cache.
+func NewClusterRole(db *db.DB) *ClusterRole {
+	return &ClusterRole{db: db}
+}
+
+// RoleRefs computes all role external references.
+func (r *ClusterRole) AggregationMatchers(refs *sync.Map) {
+	txn, it := r.db.MustITFor(internal.Glossary[internal.CR])
+	defer txn.Abort()
+	for o := it.Next(); o != nil; o = it.Next() {
+		cr := o.(*rbacv1.ClusterRole)
+		if cr.AggregationRule != nil {
+			for _, lbs := range cr.AggregationRule.ClusterRoleSelectors {
+				for k, v := range lbs.MatchLabels {
+					refs.Store(k, v)
+				}
+			}
+		}
+	}
+}

--- a/internal/cache/cr_test.go
+++ b/internal/cache/cr_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Popeye
+
+package cache_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/derailed/popeye/internal"
+	"github.com/derailed/popeye/internal/cache"
+	"github.com/derailed/popeye/internal/db"
+	"github.com/derailed/popeye/internal/test"
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestClusterRoleAggregation(t *testing.T) {
+	dba, err := test.NewTestDB()
+	assert.NoError(t, err)
+	l := db.NewLoader(dba)
+
+	ctx := test.MakeCtx(t)
+	assert.NoError(t, test.LoadDB[*rbacv1.ClusterRole](ctx, l.DB, "auth/cr/1.yaml", internal.Glossary[internal.CR]))
+
+	cr := cache.NewClusterRole(dba)
+	var aRefs sync.Map
+	cr.AggregationMatchers(&aRefs)
+
+	value, ok := aRefs.Load("rbac.authorization.k8s.io/aggregate-to-cr4")
+	assert.True(t, ok)
+	assert.Equal(t, "true", value)
+}

--- a/internal/cache/testdata/auth/cr/1.yaml
+++ b/internal/cache/testdata/auth/cr/1.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations:
+        rbac.authorization.kubernetes.io/autoupdate: "true"
+      name: cr4
+    aggregationRule:
+      clusterRoleSelectors:
+      - matchLabels:
+          rbac.authorization.k8s.io/aggregate-to-cr4: "true"
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        rbac.authorization.k8s.io/aggregate-to-cr4: "true"
+      name: cr5
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - list

--- a/internal/lint/cr_test.go
+++ b/internal/lint/cr_test.go
@@ -43,3 +43,22 @@ func TestCRLint(t *testing.T) {
 	assert.Equal(t, `[POP-400] Used? Unable to locate resource reference`, ii[0].Message)
 	assert.Equal(t, rules.InfoLevel, ii[0].Level)
 }
+
+func TestCRLintAggregations(t *testing.T) {
+	dba, err := test.NewTestDB()
+	assert.NoError(t, err)
+	l := db.NewLoader(dba)
+
+	ctx := test.MakeCtx(t)
+	assert.NoError(t, test.LoadDB[*rbacv1.ClusterRole](ctx, l.DB, "auth/cr/2.yaml", internal.Glossary[internal.CR]))
+
+	cr := NewClusterRole(test.MakeCollector(t), dba)
+	assert.Nil(t, cr.Lint(test.MakeContext("rbac.authorization.k8s.io/v1/clusterroles", "clusterroles")))
+	assert.Equal(t, 2, len(cr.Outcome()))
+
+	ii := cr.Outcome()["cr4"]
+	assert.Equal(t, 1, len(ii))
+
+	ii = cr.Outcome()["cr5"]
+	assert.Equal(t, 0, len(ii))
+}

--- a/internal/lint/testdata/auth/cr/2.yaml
+++ b/internal/lint/testdata/auth/cr/2.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations:
+        rbac.authorization.kubernetes.io/autoupdate: "true"
+      name: cr4
+    aggregationRule:
+      clusterRoleSelectors:
+      - matchLabels:
+          rbac.authorization.k8s.io/aggregate-to-cr4: "true"
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        rbac.authorization.k8s.io/aggregate-to-cr4: "true"
+      name: cr5
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - list

--- a/spinach-examples/spinach_aks.yml
+++ b/spinach-examples/spinach_aks.yml
@@ -12,7 +12,7 @@ popeye:
       # Checks if mem is over allocated by more than 50% at current load.
       overPercUtilization: 50
 
-  # Excludes define rules to exampt resources from sanitization
+  # Excludes define rules to exempt resources from sanitization
   excludes:
     global:
       fqns: [rx:kube-system]

--- a/spinach-examples/spinach_eks.yml
+++ b/spinach-examples/spinach_eks.yml
@@ -12,7 +12,7 @@ popeye:
       # Checks if mem is over allocated by more than 50% at current load.
       overPercUtilization: 50
 
-  # Excludes define rules to exampt resources from sanitization
+  # Excludes define rules to exempt resources from sanitization
   excludes:
     global:
       fqns: [rx:^kube-system,rx:^local-path-storage]


### PR DESCRIPTION
This PR fixes: #309 

This takes into consideration the roles that are used to generate other roles so that they are not marked as unused as per [aggregated-clusterroles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)