### PR TITLE
feat: Add the MIME content type to s3 uploads

### DIFF
--- a/pkg/config/s3.go
+++ b/pkg/config/s3.go
@@ -30,7 +30,7 @@ type S3Info struct {
 	Endpoint *string
 }
 
-func (s *S3Info) Upload(asset string, rwc io.ReadWriteCloser) error {
+func (s *S3Info) Upload(asset string, contentType string, rwc io.ReadWriteCloser) error {
 	defer rwc.Close()
 
 	log.Debug().Msgf("S3 bucket path: %q", asset)
@@ -54,9 +54,10 @@ func (s *S3Info) Upload(asset string, rwc io.ReadWriteCloser) error {
 	uploader := s3manager.NewUploader(session)
 	// Upload input parameters
 	upParams := s3manager.UploadInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(filepath.Join(key, asset)),
-		Body:   rwc,
+		Bucket:   aws.String(bucket),
+		Key:      aws.String(filepath.Join(key, asset)),
+		Body:     rwc,
+		Metadata: aws.StringMap(map[string]string{"Content-Type": contentType}),
 	}
 	// Perform an upload.
 	if _, err = uploader.Upload(&upParams); err != nil {

--- a/pkg/popeye.go
+++ b/pkg/popeye.go
@@ -178,7 +178,7 @@ func (p *Popeye) Lint() (int, int, error) {
 			}
 		case config.IsStrSet(p.flags.S3.Bucket):
 			asset := filepath.Join(p.clusterPath(), p.scanFileName())
-			if err := p.flags.S3.Upload(asset, p.outputTarget); err != nil {
+			if err := p.flags.S3.Upload(asset, p.fileContentType(), p.outputTarget); err != nil {
 				log.Fatal().Msgf("S3 upload failed: %s", err)
 			}
 		}
@@ -549,5 +549,22 @@ func (p *Popeye) fileExt() string {
 		return *p.flags.Output
 	default:
 		return "txt"
+	}
+}
+
+func (p *Popeye) fileContentType() string {
+	switch *p.flags.Output {
+	case "junit":
+		// https://datatracker.ietf.org/doc/html/rfc7303#section-4.1
+		return "application/xml"
+	case "json":
+		return "application/json"
+	case "yaml":
+		// https://datatracker.ietf.org/doc/html/rfc9512
+		return "application/yaml"
+	case "html":
+		return "text/html"
+	default:
+		return "text/plain"
 	}
 }


### PR DESCRIPTION
When uploading the reports to s3, it's useful to set the `Content-Type` so it can, for example, be visualized when is an html.

This small change does that based on the output selected by the user.