### PR TITLE
fix path to copyright file for nfpms

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -108,7 +108,7 @@ nfpms:
     section: utils
     contents:
       - src: ./LICENSE
-        dst: /usr/share/doc/nfpm/copyright
+        dst: /usr/share/doc/popeye/copyright
         file_info:
           mode: 0644
 


### PR DESCRIPTION
- addresses issue of not being able to install `nfpms` if you had this installed
  -  https://github.com/derailed/popeye/issues/336

- based on same fix in k9s https://github.com/derailed/k9s/pull/2780