### PR TITLE
Rel v0.21.7

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
+      # - arm
       - ppc64le
       - s390x
     # goarm:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,8 +23,8 @@ builds:
       - arm
       - ppc64le
       - s390x
-    goarm:
-      - 7
+    # goarm:
+    #   - 7
     flags:
       - -trimpath
     ldflags:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME     := popeye
 PACKAGE  := github.com/derailed/$(NAME)
-VERSION  := v0.21.6
+VERSION  := v0.21.7
 GIT      := $(shell git rev-parse --short HEAD)
 DATE     := $(shell date +%FT%T%Z)
 IMG_NAME := derailed/popeye

--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ Popeye is a readonly tool, it does not alter any of your Kubernetes resources in
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/derailed/popeye?)](https://goreportcard.com/report/github.com/derailed/popeye)
 [![codebeat badge](https://codebeat.co/badges/827e5642-3ccc-4ecc-b22b-5707dbc34cf1)](https://codebeat.co/projects/github-com-derailed-popeye-master)
-[![Build Status](https://travis-ci.com/derailed/popeye.svg?branch=master)](https://travis-ci.com/derailed/popeye)
 [![release](https://img.shields.io/github/release-pre/derailed/popeye.svg)](https://github.com/derailed/popeye/releases)
-[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/derailed/popeye/blob/master/LICENSE)
-[![docker](https://img.shields.io/docker/cloud/build/derailed/popeye?label=Docker&style=flat)](https://hub.docker.com/r/derailed/popeye/builds)
+[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/derailed/popeye/blob/master/LICENSE)x
+[![Docker Repository on Quay](https://quay.io/repository/derailed/popeye/status "Docker Repository on Quay")](https://quay.io/repository/derailed/popeye)
 ![GitHub stars](https://img.shields.io/github/stars/derailed/popeye.svg?label=github%20stars)
 [![Releases](https://img.shields.io/github/downloads/derailed/popeye/total.svg)]()
 
@@ -274,12 +273,12 @@ popeye --s3-bucket=NAME-OF-YOUR-S3-BUCKET/OPTIONAL/SUBDIRECTORY --s3-region YOUR
 
 ## Docker Support
 
-You can also run Popeye in a container by running it directly from the official docker repo on DockerHub.
+You can also run Popeye in a container by running it directly from the official docker repo on Quay.
 The default command when you run the docker container is `popeye`, so you customize the scan by using the supported cli flags.
 To access your clusters, map your local kubeconfig directory into the container with `-v` :
 
 ```shell
-docker run --rm -it -v $HOME/.kube:/root/.kube derailed/popeye --context foo -n bar
+docker run --rm -it -v $HOME/.kube:/root/.kube quay.io/derailed/popeye --context foo -n bar
 ```
 
 Running the above docker command with `--rm` means that the container gets deleted when Popeye exits.
@@ -293,7 +292,7 @@ docker run --rm -it \
   -v $HOME/.kube:/root/.kube \
   -e POPEYE_REPORT_DIR=/tmp/popeye \
   -v /tmp:/tmp \
-  derailed/popeye --context foo -n bar --save --output-file my_report.txt
+  quay.io/derailed/popeye --context foo -n bar --save --output-file my_report.txt
 
 # Docker has exited, and the container has been deleted, but the file
 # is in your /tmp directory because you mapped it into the container

--- a/change_logs/release_v0.21.7.md
+++ b/change_logs/release_v0.21.7.md
@@ -1,0 +1,28 @@
+<img src="https://raw.githubusercontent.com/derailed/popeye/master/assets/popeye_logo.png" align="right" width="200" height="auto"/>
+
+# Release v0.21.7
+
+## Notes
+
+Thank you to all that contributed with flushing out issues and enhancements for Popeye! I'll try to mark some of these issues as fixed. But if you don't mind grab the latest rev and see if we're happier with some of the fixes! If you've filed an issue please help me verify and close. Your support, kindness and awesome suggestions to make Popeye better is as ever very much noticed and appreciated!
+
+This project offers a GitHub Sponsor button (over here 👆). As you well know this is not pimped out by big corps with deep pockets. If you feel `Popeye` is saving you cycles diagnosing potential cluster issues please consider sponsoring this project!! It does go a long way in keeping our servers lights on and beers in our fridge.
+
+Also if you dig this tool, please make some noise on social! [@kitesurfer](https://twitter.com/kitesurfer)
+
+---
+
+## Maintenance Release
+
+---
+
+## Resolved Issues
+
+* [#414](https://github.com/derailed/popeye/issues/414) Why are there fewer inspection indicators in the new version (0.21.6)?
+* [#413](https://github.com/derailed/popeye/issues/413) new version 0.21.6 is not scaning any namespace
+* [#408](https://github.com/derailed/popeye/issues/408) v0.21.6 popeye -s po returns nothing and "Booms" with message "No linters matched query"
+* [#388](https://github.com/derailed/popeye/issues/388) Filter by namespace intermittently includes all namespaces
+
+---
+
+<img src="https://raw.githubusercontent.com/derailed/popeye/master/assets/imhotep_logo.png" width="32" height="auto"/>&nbsp; © 2024 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Popeye
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/derailed/popeye/internal/report"
+	"github.com/derailed/popeye/pkg"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(infoCmd())
+}
+
+func infoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "info",
+		Short: "Prints Popeye info",
+		Long:  "Prints Popeye information",
+		Run: func(cmd *cobra.Command, args []string) {
+			printInfo()
+		},
+	}
+}
+
+func printInfo() {
+	printLogo(report.ColorAqua, report.ColorLighSlate)
+	fmt.Println()
+	printTuple("Logs", pkg.LogFile)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,17 +30,16 @@ var (
 	}
 )
 
+func init() {
+	initFlags()
+}
+
 func execName() string {
 	n := "popeye"
 	if strings.HasPrefix(filepath.Base(os.Args[0]), "kubectl-") {
 		return "kubectl-" + n
 	}
 	return n
-}
-
-func init() {
-	rootCmd.AddCommand(versionCmd())
-	initFlags()
 }
 
 // Execute root command

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,9 +8,12 @@ import (
 	"strings"
 
 	"github.com/derailed/popeye/internal/report"
-	"github.com/derailed/popeye/pkg"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	rootCmd.AddCommand(versionCmd())
+}
 
 func versionCmd() *cobra.Command {
 	return &cobra.Command{
@@ -28,7 +31,6 @@ func printVersion() {
 	printTuple("Version", version)
 	printTuple("Commit", commit)
 	printTuple("Date", date)
-	printTuple("Logs", pkg.LogFile)
 }
 
 func printTuple(section, value string) {

--- a/internal/alias.go
+++ b/internal/alias.go
@@ -219,6 +219,7 @@ func (a *Aliases) Exclude(gvr types.GVR, sections []string) bool {
 	if len(sections) == 0 {
 		return false
 	}
+
 	var matches int
 	for _, s := range sections {
 		agvr, ok := a.aliases[s]

--- a/internal/cilium/lint/ccnp.go
+++ b/internal/cilium/lint/ccnp.go
@@ -128,9 +128,12 @@ func (s *CiliumClusterwideNetworkPolicy) matchNodesBySel(sel api.EndpointSelecto
 		if !ok {
 			return nil, fmt.Errorf("expecting node but got %s", o)
 		}
-		fqn := client.FQN("", no.Name)
-		if matchSelector(no.Labels, sel) {
-			mm = append(mm, fqn)
+		ll := make([]string, 0, len(no.Labels))
+		for k, v := range no.Labels {
+			ll = append(ll, k+"="+v)
+		}
+		if matchSelector(client.AllNamespaces, ll, sel) {
+			mm = append(mm, client.FQN("", no.Name))
 		}
 	}
 
@@ -148,9 +151,11 @@ func (s *CiliumClusterwideNetworkPolicy) matchCEPsBySel(sel api.EndpointSelector
 		if !ok {
 			return nil, fmt.Errorf("expecting cilium endpoint but got %s", o)
 		}
-		fqn := client.FQN(cep.Namespace, cep.Name)
-		if matchSelector(cep.Labels, sel) {
-			mm = append(mm, fqn)
+		if cep.Status.Identity == nil {
+			continue
+		}
+		if matchSelector(cep.Namespace, cep.Status.Identity.Labels, sel) {
+			mm = append(mm, client.FQN(cep.Namespace, cep.Name))
 		}
 	}
 

--- a/internal/cilium/lint/cid_test.go
+++ b/internal/cilium/lint/cid_test.go
@@ -31,7 +31,6 @@ func TestCiliumIdentity(t *testing.T) {
 	assert.Nil(t, li.Lint(test.MakeContext("cilium.io/v2/ciliumidentities", "ciliumidentities")))
 	assert.Equal(t, 3, len(li.Outcome()))
 
-	li.Outcome().Dump()
 	ii := li.Outcome()["default/100"]
 	assert.Equal(t, 0, len(ii))
 

--- a/internal/cilium/lint/cnp_test.go
+++ b/internal/cilium/lint/cnp_test.go
@@ -28,7 +28,6 @@ func TestCiliumNetworkPolicy(t *testing.T) {
 	assert.Nil(t, li.Lint(test.MakeContext("cilium.io/v2/ciliumnetworkpolicies", "ciliumnetworkpolicies")))
 	assert.Equal(t, 4, len(li.Outcome()))
 
-	li.Outcome().Dump()
 	ii := li.Outcome()["default/cnp1"]
 	assert.Equal(t, 0, len(ii))
 

--- a/internal/cilium/lint/testdata/cep/1.yaml
+++ b/internal/cilium/lint/testdata/cep/1.yaml
@@ -26,7 +26,7 @@ items:
       - k8s:io.cilium.k8s.policy.cluster=fred
       - k8s:io.cilium.k8s.policy.serviceaccount=sa1
       - k8s:io.kubernetes.pod.namespace=default
-      - k8s:app=p1
+      - k8s:k8s-app=cep1
     named-ports:
     - name: dns
       port: 53
@@ -69,7 +69,7 @@ items:
       - k8s:io.cilium.k8s.policy.cluster=fred
       - k8s:io.cilium.k8s.policy.serviceaccount=sa1
       - k8s:io.kubernetes.pod.namespace=default
-      - k8s:app=cid2
+      - k8s:k8s-app=cep2
     named-ports:
     - name: dns
       port: 53

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -64,9 +64,8 @@ func InitConnectionOrDie(config types.Config) (*APIClient, error) {
 		config: config,
 		cache:  cache.NewLRUExpireCache(cacheSize),
 	}
-	_, err := a.serverGroups()
-	if err != nil {
-		return nil, err
+	if _, err := a.serverGroups(); err != nil {
+		return nil, fmt.Errorf("init connection fail: %w", err)
 	}
 	if err := a.supportsMetricsResources(); err != nil {
 		log.Warn().Err(err).Msgf("no metrics server detected")
@@ -366,7 +365,7 @@ func (a *APIClient) serverGroups() (*metav1.APIGroupList, error) {
 	dial, err := a.CachedDiscovery()
 	if err != nil {
 		log.Warn().Err(err).Msgf("Unable to dial discovery API")
-		return nil, err
+		return nil, fmt.Errorf("unable to dial discovery: %w", err)
 	}
 	apiGroups, err := dial.ServerGroups()
 	if err != nil {
@@ -391,7 +390,7 @@ func (a *APIClient) supportsMetricsResources() error {
 
 	gg, err := a.serverGroups()
 	if err != nil {
-		return err
+		return fmt.Errorf("supportmetricsResources call fail: %w", err)
 	}
 	for _, grp := range gg.Groups {
 		if grp.Name != metricsapi.GroupName {

--- a/internal/keys.go
+++ b/internal/keys.go
@@ -8,13 +8,14 @@ type ContextKey string
 
 // A collection of context keys.
 const (
-	KeyFactory    ContextKey = "factory"
-	KeyLabels     ContextKey = "labels"
-	KeyFields     ContextKey = "fields"
-	KeyOverAllocs ContextKey = "overAllocs"
-	KeyRunInfo    ContextKey = "runInfo"
-	KeyConfig     ContextKey = "config"
-	KeyNamespace  ContextKey = "namespace"
-	KeyVersion    ContextKey = "version"
-	KeyDB         ContextKey = "db"
+	KeyFactory       ContextKey = "factory"
+	KeyLabels        ContextKey = "labels"
+	KeyFields        ContextKey = "fields"
+	KeyOverAllocs    ContextKey = "overAllocs"
+	KeyRunInfo       ContextKey = "runInfo"
+	KeyConfig        ContextKey = "config"
+	KeyNamespace     ContextKey = "namespace"
+	KeyVersion       ContextKey = "version"
+	KeyDB            ContextKey = "db"
+	KeyNamespaceName ContextKey = "namespaceName"
 )

--- a/internal/lint/ns.go
+++ b/internal/lint/ns.go
@@ -37,21 +37,21 @@ func (s *Namespace) Lint(ctx context.Context) error {
 	if err := s.ReferencedNamespaces(used); err != nil {
 		s.AddErr(ctx, err)
 	}
-	txn, it := s.db.MustITFor(internal.Glossary[internal.NS])
-	defer txn.Abort()
 
-	cns, ok := ctx.Value(internal.KeyNamespace).(string)
+	cns, ok := ctx.Value(internal.KeyNamespaceName).(string)
 	if !ok {
-		cns = client.BlankNamespace
+		cns = client.AllNamespaces
 	}
 
+	txn, it := s.db.MustITFor(internal.Glossary[internal.NS])
+	defer txn.Abort()
 	for o := it.Next(); o != nil; o = it.Next() {
 		ns, ok := o.(*v1.Namespace)
 		if !ok {
 			return errors.New("expected ns")
 		}
 		fqn := ns.Name
-		if cns != client.BlankNamespace && fqn != cns {
+		if client.IsNamespaced(cns) && fqn != cns {
 			continue
 		}
 		s.InitOutcome(fqn)

--- a/pkg/config/flags_test.go
+++ b/pkg/config/flags_test.go
@@ -4,8 +4,6 @@
 package config
 
 import (
-	"errors"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,58 +101,6 @@ func TestOutputFormat(t *testing.T) {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
 			assert.Equal(t, u.e, u.f.OutputFormat())
-		})
-	}
-}
-
-func TestParseBucket(t *testing.T) {
-	var uu = map[string]struct {
-		uri    string
-		bucket string
-		key    string
-		err    error
-	}{
-		"empty": {
-			err: errors.New(`invalid S3 bucket URI: ""`),
-		},
-		"no-scheme": {
-			uri: ":bozo",
-			err: &url.Error{Op: "parse", URL: ":bozo", Err: errors.New("missing protocol scheme")},
-		},
-		"s3_bucket": {
-			uri:    "s3://bucketName/",
-			bucket: "bucketName",
-		},
-		"toast": {
-			uri: "s4://bucketName/",
-			err: errors.New(`invalid S3 bucket URI: "s4://bucketName/"`),
-		},
-		"with_full_key": {
-			uri:    "s3://bucketName/fred/blee",
-			bucket: "bucketName",
-			key:    "fred/blee",
-		},
-		"with_key": {
-			uri:    "bucket/with/subkey",
-			bucket: "bucket",
-			key:    "with/subkey",
-		},
-		"with_trailer": {
-			uri:    "/bucket/with/leading/slashes/",
-			bucket: "bucket",
-			key:    "with/leading/slashes",
-		},
-	}
-
-	for k := range uu {
-		u := uu[k]
-		t.Run(k, func(t *testing.T) {
-			s3 := S3Info{Bucket: &u.uri}
-			b, k, err := s3.parse()
-
-			assert.Equal(t, u.err, err)
-			assert.Equal(t, u.bucket, b)
-			assert.Equal(t, u.key, k)
 		})
 	}
 }

--- a/pkg/config/s3_test.go
+++ b/pkg/config/s3_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Popeye
+
+package config
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBucket(t *testing.T) {
+	var uu = map[string]struct {
+		uri    string
+		host   string
+		bucket string
+		key    string
+		err    error
+	}{
+		"empty": {
+			err: errors.New(`invalid S3 bucket URI: ""`),
+		},
+		"no-scheme": {
+			uri: ":bozo",
+			err: &url.Error{Op: "parse", URL: ":bozo", Err: errors.New("missing protocol scheme")},
+		},
+		"s3_bucket": {
+			uri:    "s3://bucketName/",
+			bucket: "bucketName",
+		},
+		"s3-toast": {
+			uri: "s4://bucketName/",
+			err: errors.New(`invalid S3 bucket URI: "s4://bucketName/"`),
+		},
+		"s3-with_full_key": {
+			uri:    "s3://bucketName/fred/blee",
+			bucket: "bucketName",
+			key:    "fred/blee",
+		},
+		"s3-with_key": {
+			uri:    "bucket/with/subkey",
+			bucket: "bucket",
+			key:    "with/subkey",
+		},
+		"s3-with_trailer": {
+			uri:    "/bucket/with/leading/slashes/",
+			bucket: "bucket",
+			key:    "with/leading/slashes",
+		},
+		"minio": {
+			uri:    "minio://hostname:9000/bucketName/",
+			bucket: "bucketName",
+			host:   "hostname:9000",
+		},
+		"minio-with_key": {
+			uri:    "minio://hostname:9000/bucketName/with/subkey/to/test",
+			bucket: "bucketName",
+			key:    "with/subkey/to/test",
+			host:   "hostname:9000",
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			s3 := S3Info{Bucket: &u.uri}
+			h, b, k, err := s3.parse()
+
+			assert.Equal(t, u.err, err)
+			assert.Equal(t, u.host, h)
+			assert.Equal(t, u.bucket, b)
+			assert.Equal(t, u.key, k)
+		})
+	}
+}


### PR DESCRIPTION
## Resolved Issues

* [#414](https://github.com/derailed/popeye/issues/414) Why are there fewer inspection indicators in the new version (0.21.6)?
* [#413](https://github.com/derailed/popeye/issues/413) new version 0.21.6 is not scaning any namespace
* [#408](https://github.com/derailed/popeye/issues/408) v0.21.6 popeye -s po returns nothing and "Booms" with message "No linters matched query"
* [#388](https://github.com/derailed/popeye/issues/388) Filter by namespace intermittently includes all namespaces
