### PR TITLE
Add Krew Installation Instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Popeye is available on Linux, OSX and Windows platforms.
    brew install derailed/popeye/popeye
    ```
 
+* Using [Krew](https://krew.sigs.k8s.io/) (kubectl plugin manager)
+
+   ```shell
+   kubectl krew install popeye
+   ```
+
 * Using `go install`
 
     ```shell


### PR DESCRIPTION
This PR updates the [README.md](https://shiny-space-waddle-rr9q7r6qg639v7.github.dev/) to include installation instructions for Popeye using [Krew](https://shiny-space-waddle-rr9q7r6qg639v7.github.dev/), the kubectl plugin manager. The new section is placed immediately after the Homebrew/LinuxBrew installation method, making it easier for users to discover and install Popeye as a kubectl plugin. No other documentation or code changes are included.