### PR TITLE
Improved minio support and updated documentation for running inside the cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME     := popeye
 PACKAGE  := github.com/derailed/$(NAME)
-VERSION  := v0.22.1
+VERSION  := v0.22.2
 GIT      := $(shell git rev-parse --short HEAD)
 DATE     := $(shell date +%FT%T%Z)
 IMG_NAME := derailed/popeye

--- a/README.md
+++ b/README.md
@@ -513,9 +513,14 @@ spec:
               image: derailed/popeye:vX.Y.Z
               imagePullPolicy: IfNotPresent
               args:
-                - -o
+                - --out
                 - yaml
                 - --force-exit-zero
+                - --logs
+                - none
+                - --cluster-name
+                - my-cluster
+                - --all-namespaces
               resources:
                 limits:
                   cpu:    500m

--- a/README.md
+++ b/README.md
@@ -528,6 +528,9 @@ spec:
 ```
 
 The `--force-exit-zero` should be set. Otherwise, the pods will end up in an error state.
+The `--logs none` argument must be set to output the log to stdout. Otherwise `kubectl logs -f` will return an empty result.
+The `--cluster-name` should be set to the name of your cluster for in-cluster usage.
+
 
 > NOTE! Popeye exits with a non-zero error code if any lint errors are detected.
 

--- a/k8s/popeye/cronjob.yml
+++ b/k8s/popeye/cronjob.yml
@@ -20,10 +20,16 @@ spec:
               imagePullPolicy: IfNotPresent
               command: ["/bin/popeye"]
               args:
-                - -f
+                - --file
                 - /etc/config/popeye/spinach.yml
-                - -o
+                - --out
                 - yaml
+                - --force-exit-zero
+                - --logs
+                - none
+                - --cluster-name
+                - my-cluster
+                - --all-namespaces
               resources:
                 limits:
                   cpu: 500m

--- a/pkg/config/s3.go
+++ b/pkg/config/s3.go
@@ -90,6 +90,17 @@ func (s *S3Info) minioUpload(ctx context.Context, bucket, key, asset string, rwc
 	}
 
 	contentType := "application/octet-stream"
+	fileExtension := filepath.Ext(asset)
+
+	switch fileExtension {
+	case ".html":
+		contentType = "text/html"
+	case ".json":
+		contentType = "application/json"
+	case ".yaml", ".yml":
+		contentType = "application/yaml"
+	}
+
 	info, err := minioClient.PutObject(ctx,
 		bucket,
 		filepath.Join(key, asset),

--- a/pkg/config/s3.go
+++ b/pkg/config/s3.go
@@ -91,8 +91,7 @@ func (s *S3Info) minioUpload(ctx context.Context, bucket, key, asset string, rwc
 
 	contentType := "application/octet-stream"
 	fileExtension := filepath.Ext(asset)
-
-	log.Info().Msgf("s3 file metadata: %q\n%q\n%q", filepath, fileExtension, asset)
+	log.Debug().Msgf("s3 file metadata: %q\n%q\n%q", filepath, fileExtension, asset)
 
 	switch fileExtension {
 	case ".html":

--- a/pkg/config/s3.go
+++ b/pkg/config/s3.go
@@ -92,6 +92,10 @@ func (s *S3Info) minioUpload(ctx context.Context, bucket, key, asset string, rwc
 	contentType := "application/octet-stream"
 	fileExtension := filepath.Ext(asset)
 
+	log.Debug().Msgf("Filepath: %q", asset)
+	log.Debug().Msgf("Filepath: %q", fullFilePath)
+	log.Debug().Msgf("File Extension: %q", fileExtension)
+
 	switch fileExtension {
 	case ".html":
 		contentType = "text/html"

--- a/pkg/config/s3.go
+++ b/pkg/config/s3.go
@@ -91,9 +91,6 @@ func (s *S3Info) minioUpload(ctx context.Context, bucket, key, asset string, rwc
 
 	contentType := "application/octet-stream"
 	fileExtension := filepath.Ext(asset)
-	log.Debug().Msgf("s3 local report file: %q", asset)
-	log.Debug().Msgf("s3 local report file extension: %q", fileExtension)
-	log.Debug().Msgf("s3 local report file path: %q", filepath.Join(key, asset))
 
 	switch fileExtension {
 	case ".html":

--- a/pkg/config/s3.go
+++ b/pkg/config/s3.go
@@ -91,7 +91,9 @@ func (s *S3Info) minioUpload(ctx context.Context, bucket, key, asset string, rwc
 
 	contentType := "application/octet-stream"
 	fileExtension := filepath.Ext(asset)
-	log.Debug().Msgf("s3 file metadata: %q\n%q\n%q", filepath, fileExtension, asset)
+	log.Debug().Msgf("s3 local report file: %q", asset)
+	log.Debug().Msgf("s3 local report file extension: %q", fileExtension)
+	log.Debug().Msgf("s3 local report file path: %q", filepath.Join(key, asset))
 
 	switch fileExtension {
 	case ".html":

--- a/pkg/config/s3.go
+++ b/pkg/config/s3.go
@@ -92,9 +92,7 @@ func (s *S3Info) minioUpload(ctx context.Context, bucket, key, asset string, rwc
 	contentType := "application/octet-stream"
 	fileExtension := filepath.Ext(asset)
 
-	log.Debug().Msgf("Filepath: %q", asset)
-	log.Debug().Msgf("Filepath: %q", fullFilePath)
-	log.Debug().Msgf("File Extension: %q", fileExtension)
+	log.Info().Msgf("s3 file metadata: %q\n%q\n%q", filepath, fileExtension, asset)
 
 	switch fileExtension {
 	case ".html":


### PR DESCRIPTION
Hello everyone! Thank you for this very useful tool, which significantly improves operational safety in my cases.

I recently deployed Popeye inside a Kubernetes cluster as a CronJob and use Minio as a repository for reports.
During testing, I identified a couple of areas for improvement, which I've already validated in my environment. I believe these changes could benefit the wider community:
- **Updated in-cluster documentation examples:** I've updated the Kubernetes manifests (CronJob) in the documentation to provide clearer and more accurate examples for running Popeye within a Kubernetes cluster.
- **Corrected Content-Type for Minio reports:** When attempting to view reports in Minio via a browser, I noticed that they were always downloaded locally. This was because the `Content-Type` of the uploaded objects was consistently set to `application/octet-stream`. For HTML reports, setting the `Content-Type` to `text/html` allows users to open the reports directly in the browser via a direct link. I've implemented a change in [s3.go](pkg/config/s3.go) to ensure the correct `Content-Type` is set for HTML, JSON and YAML reports when uploading to Minio.

Perhaps these enhancements will be valuable to others!