### PR TITLE
Handle Image Name/Tag parsing correctly with namespaced images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,8 @@ require (
 	github.com/cilium/hive v0.0.0-20240529072208-d997f86e4219 // indirect
 	github.com/cilium/proxy v0.0.0-20241210133824-eaae5aca0fb9 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/distribution/reference v0.5.0 // indirect
+	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
@@ -108,6 +110,7 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,10 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
+github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
+github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.12.0 h1:y2DdzBAURM29NFF94q6RaY4vjIH1rtwDapwQtU84iWk=
@@ -216,6 +220,8 @@ github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=

--- a/internal/lint/container_test.go
+++ b/internal/lint/container_test.go
@@ -229,7 +229,7 @@ func TestContainerCheckImageRegistry(t *testing.T) {
 
 		l := NewContainer("default/p1", newRangeCollectorWithRegistry(t))
 		t.Run(k, func(t *testing.T) {
-			l.checkImageTags(ctx, co.Image)
+			l.checkImageRegistry(ctx, co.Image)
 
 			assert.Equal(t, u.pissues, len(l.Outcome()["default/p1"]))
 			if len(l.Outcome()["default/p1"]) != 0 {

--- a/internal/lint/container_test.go
+++ b/internal/lint/container_test.go
@@ -213,7 +213,10 @@ func TestContainerCheckImageRegistry(t *testing.T) {
 	}{
 		"dockerDefault": {image: "dockerhub:1.2.3", issues: 0},
 		"cool":          {image: "docker.io/cool:1.2.3", issues: 0},
+		"namespacedCoolDefault": {image: "namespace/cool:1.2.3", issues: 0},
+		"namespacedCool": {image: "docker.io/namespace/cool:1.2.3", issues: 0},
 		"wrongRegistry": {pissues: 1, image: "wrong-registry.io/fred", issues: 1, severity: rules.ErrorLevel},
+		"namespacedWrongRegistry": {pissues: 1, image: "wrong-registry.io/namespace/fred", issues: 1, severity: rules.ErrorLevel},
 	}
 
 	ctx := test.MakeContext("containers", "container")


### PR DESCRIPTION
### What

This PR switches image name/tag checks to use [github.com/distribution/reference](https://github.com/distribution/reference). This should be a more robust solution and handle edge cases better than the current strings.Split approach 😄.

### Why

With the current implementation, Popeye flagged certain namespaced images as coming from a non-allowed registry, even when no registry was explicitly provided (which should default to docker.io). This led to false positives for me.

### Notes

I’ve added tests that highlight the cases which were parsed incorrectly before, so it should be clearer what’s fixed now.

Thanks a lot for taking a look!

P.S. I reopened this PR because my initial tests were misleading — they were passing even without my changes. I realized the wrong method was being called in the test, so I’ve included that fix here as well 😅. Sorry for the extra notification spam!